### PR TITLE
fix: 시간순 정렬 쿼리 추가

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/repository/CommentRepository.java
@@ -17,6 +17,7 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
             FROM CommentEntity as c JOIN OfferingMemberEntity as om
                 ON c.offering = om.offering AND c.member = om.member
             WHERE om.offering = :offering
+            ORDER BY c.createdAt
         """)
     List<CommentWithRole> findAllWithRoleByOffering(OfferingEntity offering);
 


### PR DESCRIPTION
## 📌 관련 이슈
close #81 
## ✨ 작업 내용
- 댓글 목록 조회 시 시간순으로 정렬되지 않는 쿼리를 수정
## 📚 기타
