### PR TITLE
fix: 마지막 댓글 response를 nullable하게 수정

### DIFF
--- a/android/app/src/main/java/com/zzang/chongdae/data/mapper/CommentRoomResponseMapper.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/mapper/CommentRoomResponseMapper.kt
@@ -2,13 +2,14 @@ package com.zzang.chongdae.data.mapper
 
 import com.zzang.chongdae.data.remote.dto.response.CommentRoomResponse
 import com.zzang.chongdae.domain.model.CommentRoom
+import java.time.LocalDateTime
 
 fun CommentRoomResponse.toDomain(): CommentRoom {
     return CommentRoom(
         id = this.offeringId,
         title = this.offeringTitle,
-        latestComment = this.latestComment.content,
-        latestCommentTime = this.latestComment.createdAt.toLocalDateTime(),
+        latestComment = this.latestComment.content ?: "",
+        latestCommentTime = this.latestComment.createdAt?.toLocalDateTime(),
         isProposer = this.isProposer,
     )
 }

--- a/android/app/src/main/java/com/zzang/chongdae/data/remote/dto/response/LatestCommentResponse.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/remote/dto/response/LatestCommentResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LatestCommentResponse(
-    @SerialName("content") val content: String,
-    @SerialName("createdAt") val createdAt: String,
+    @SerialName("content") val content: String?,
+    @SerialName("createdAt") val createdAt: String?,
 )

--- a/android/app/src/main/java/com/zzang/chongdae/domain/model/CommentRoom.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/domain/model/CommentRoom.kt
@@ -6,6 +6,6 @@ data class CommentRoom(
     val id: Long,
     val title: String,
     val latestComment: String,
-    val latestCommentTime: LocalDateTime,
+    val latestCommentTime: LocalDateTime?,
     val isProposer: Boolean,
 )

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/util/BindingAdapters.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/util/BindingAdapters.kt
@@ -139,8 +139,8 @@ fun setLayoutHeightWithAnimation(
 }
 
 @BindingAdapter("formattedAmPmTime")
-fun TextView.setTime(localDateTime: LocalDateTime) {
-    this.text = localDateTime.format(DateTimeFormatter.ofPattern(context.getString(R.string.amPmTime), Locale.KOREAN))
+fun TextView.setTime(localDateTime: LocalDateTime?) {
+    this.text = localDateTime?.format(DateTimeFormatter.ofPattern(context.getString(R.string.amPmTime), Locale.KOREAN)) ?: ""
 }
 
 private fun Int.toPx(context: Context): Int {


### PR DESCRIPTION
## 📌 관련 이슈
close #114 
## ✨ 작업 내용
마지막 댓글의 response를 nullable하게 수정했습니다! null일 경우 해당 textview가 `""`(빈 문자열)로 뜹니다.
![image](https://github.com/user-attachments/assets/557131d6-ff43-4ba0-a98a-c75792da0c21)


## 📚 기타
