### PR TITLE
chore: CI 빌드 스크립트 중 중복되는 task 제거해 성능 개선

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ "develop-BE" ]
     paths: [ "backend/**" ]
-  pull_request:
-    branches: [ "develop-BE" ]
+  # pull_request:
+  #   branches: [ "develop-BE" ]
 
 jobs:
 
@@ -38,10 +38,7 @@ jobs:
 #        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5
 
       - name: Build with Gradle Wrapper
-        run: |
-          ./gradlew clean
-          ./gradlew copyOasToSwagger
-          ./gradlew build
+        run: ./gradlew clean build
         working-directory: ./backend
 
       - name: Docker build and push

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ "develop-BE" ]
     paths: [ "backend/**" ]
-  # pull_request:
-  #   branches: [ "develop-BE" ]
+  pull_request:
+    branches: [ "develop-BE" ]
 
 jobs:
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -68,3 +68,7 @@ tasks.register('copyOasToSwagger', Copy) {
 bootJar {
     dependsOn copyOasToSwagger
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
## 📌 관련 이슈
close #110 

## ✨ 작업 내용
-  jar 태스크 비활성화하고 bootJar 태스크로만 JAR 파일 생성

## 📚 기타
- 🍀해결 완!🍀 `./gradlew clean build` 명령어 하나만으로도 API docs 배포 환경에서 정상적으로 뜨는 거 확인했습니다:)

[원인]
- jar task와 bootJar task 둘다 JAR 파일을 생성하는 task인데, 원래 build 과정에서 둘다 실행해서 문제였습니다.
- 아마 기존엔 앞에 jar task 로 만든 JAR 파일을 캐싱해 사용한 거 같습니다.

[해결]
- jar task를 비활성화했습니다.

[정보]
- jar task: 라이브러리를 생성하거나, 종속성을 직접 관리하는 경우에 유용
- bootJar task: Spring Boot 애플리케이션을 배포하고 실행 가능한 형태로 패키징하는데 사용