### PR TITLE
feat: 댓글방 메시지 조회 시 commentId 필드 추가

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
@@ -6,10 +6,10 @@ import com.zzang.chongdae.comment.repository.entity.CommentEntity;
 import com.zzang.chongdae.comment.service.dto.CommentAllResponse;
 import com.zzang.chongdae.comment.service.dto.CommentAllResponseItem;
 import com.zzang.chongdae.comment.service.dto.CommentCreatedAtResponse;
+import com.zzang.chongdae.comment.service.dto.CommentLatestResponse;
 import com.zzang.chongdae.comment.service.dto.CommentRoomAllResponse;
 import com.zzang.chongdae.comment.service.dto.CommentRoomAllResponseItem;
 import com.zzang.chongdae.comment.service.dto.CommentSaveRequest;
-import com.zzang.chongdae.comment.service.dto.CommentLatestResponse;
 import com.zzang.chongdae.global.exception.MarketException;
 import com.zzang.chongdae.member.exception.MemberErrorCode;
 import com.zzang.chongdae.member.repository.MemberRepository;
@@ -94,6 +94,7 @@ public class CommentService {
         OfferingMemberRole role = commentWithRole.getRole();
         MemberEntity member = comment.getMember();
         return new CommentAllResponseItem(
+                comment.getId(),
                 new CommentCreatedAtResponse(comment.getCreatedAt()),
                 comment.getContent(),
                 member.getNickname(),

--- a/backend/src/main/java/com/zzang/chongdae/comment/service/dto/CommentAllResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/dto/CommentAllResponseItem.java
@@ -1,6 +1,7 @@
 package com.zzang.chongdae.comment.service.dto;
 
-public record CommentAllResponseItem(CommentCreatedAtResponse createdAt,
+public record CommentAllResponseItem(Long commentId,
+                                     CommentCreatedAtResponse createdAt,
                                      String content,
                                      String nickname,
                                      Boolean isProposer,

--- a/backend/src/test/java/com/zzang/chongdae/comment/integration/CommentIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/comment/integration/CommentIntegrationTest.java
@@ -124,6 +124,7 @@ public class CommentIntegrationTest extends IntegrationTest {
                 parameterWithName("member-id").description("회원 id")
         );
         List<FieldDescriptor> getAllCommentResponseDescriptors = List.of(
+                fieldWithPath("comments[].commentId").description("댓글 id"),
                 fieldWithPath("comments[].createdAt.date").description("작성 날짜"),
                 fieldWithPath("comments[].createdAt.time").description("작성 시간"),
                 fieldWithPath("comments[].content").description("내용"),


### PR DESCRIPTION
## 📌 관련 이슈
close #149 
## ✨ 작업 내용
- 댓글방 메시지 조회 시 commentId 필드 추가
## 📚 기타
