### PR TITLE
refactor: 제품 코드와 API 문서 동기화

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/controller/CommentController.java
@@ -29,7 +29,7 @@ public class CommentController {
 
     @GetMapping("/comments")
     public ResponseEntity<CommentRoomAllResponse> getAllCommentRoom(
-            @RequestParam(value = "member-id") @Valid Long loginMemberId) {
+            @RequestParam(value = "member-id") Long loginMemberId) {
         CommentRoomAllResponse response = commentService.getAllCommentRoom(loginMemberId);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/zzang/chongdae/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.zzang.chongdae.comment.service.CommentService;
 import com.zzang.chongdae.comment.service.dto.CommentAllResponse;
 import com.zzang.chongdae.comment.service.dto.CommentRoomAllResponse;
 import com.zzang.chongdae.comment.service.dto.CommentSaveRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,14 +22,14 @@ public class CommentController {
 
     @PostMapping("/comments")
     public ResponseEntity<Void> saveComment(
-            @RequestBody CommentSaveRequest request) {
+            @RequestBody @Valid CommentSaveRequest request) {
         commentService.saveComment(request);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/comments")
     public ResponseEntity<CommentRoomAllResponse> getAllCommentRoom(
-            @RequestParam(value = "member-id") Long loginMemberId) {
+            @RequestParam(value = "member-id") @Valid Long loginMemberId) {
         CommentRoomAllResponse response = commentService.getAllCommentRoom(loginMemberId);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/zzang/chongdae/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/zzang/chongdae/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.zzang.chongdae.global.exception;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,5 +14,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorResponse.getStatus())
                 .body(errorResponse.getErrorMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(MethodArgumentNotValidException e) {
+        ErrorMessage errorMessage = new ErrorMessage(e.getAllErrors().get(0).getDefaultMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(errorMessage);
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/config/OfferingConfig.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/config/OfferingConfig.java
@@ -9,12 +9,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OfferingConfig {
 
-    // TODO: 시간 단위 의미 넣기
-    private static final int CRAWLER_READ_TIMEOUT = 1000;
+    private static final int CRAWLER_TIMEOUT_MILLISECONDS = 1000;
 
     @Bean
     public HtmlCrawler htmlCrawler() {
-        return new JsoupHtmlCrawler(CRAWLER_READ_TIMEOUT);
+        return new JsoupHtmlCrawler(CRAWLER_TIMEOUT_MILLISECONDS);
     }
 
     @Bean

--- a/backend/src/main/java/com/zzang/chongdae/offering/config/OfferingConfig.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/config/OfferingConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OfferingConfig {
 
+    // TODO: 시간 단위 의미 넣기
     private static final int CRAWLER_READ_TIMEOUT = 1000;
 
     @Bean

--- a/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingController.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingController.java
@@ -56,7 +56,7 @@ public class OfferingController {
 
     @PostMapping("/offerings/product-images/og")
     public ResponseEntity<OfferingProductImageResponse> extractProductImage(
-            @RequestBody OfferingProductImageRequest request) {
+            @RequestBody @Valid OfferingProductImageRequest request) {
         OfferingProductImageResponse response = offeringService.extractProductImage(request);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingController.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingController.java
@@ -7,6 +7,7 @@ import com.zzang.chongdae.offering.service.dto.OfferingMeetingResponse;
 import com.zzang.chongdae.offering.service.dto.OfferingProductImageRequest;
 import com.zzang.chongdae.offering.service.dto.OfferingProductImageResponse;
 import com.zzang.chongdae.offering.service.dto.OfferingSaveRequest;
+import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -48,7 +49,7 @@ public class OfferingController {
 
     @PostMapping("/offerings")
     public ResponseEntity<Void> saveOffering(
-            @RequestBody OfferingSaveRequest request) {
+            @RequestBody @Valid OfferingSaveRequest request) {
         Long offeringId = offeringService.saveOffering(request);
         return ResponseEntity.created(URI.create("/offerings/" + offeringId)).build();
     }

--- a/backend/src/main/java/com/zzang/chongdae/offering/service/dto/OfferingSaveRequest.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/service/dto/OfferingSaveRequest.java
@@ -1,20 +1,42 @@
 package com.zzang.chongdae.offering.service.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
-public record OfferingSaveRequest(Long memberId,
+public record OfferingSaveRequest(@NotNull
+                                  Long memberId,
+
+                                  @NotBlank
                                   String title,
+
                                   String productUrl,
+
                                   String thumbnailUrl,
+
+                                  @NotNull
                                   Integer totalCount,
+
+                                  @NotNull
                                   Integer totalPrice,
+
                                   Integer eachPrice,
+
+                                  @NotBlank
                                   String meetingAddress,
+
                                   String meetingAddressDetail,
+
                                   String meetingAddressDong,
+
+                                  @NotNull
+                                  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
                                   LocalDateTime deadline,
+
+                                  @NotNull
                                   String description) {
 
     public OfferingEntity toEntity(MemberEntity member) {

--- a/backend/src/main/java/com/zzang/chongdae/offering/util/httpclient/JsoupHtmlCrawler.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/util/httpclient/JsoupHtmlCrawler.java
@@ -10,13 +10,13 @@ import org.jsoup.select.Elements;
 @RequiredArgsConstructor
 public class JsoupHtmlCrawler implements HtmlCrawler {
 
-    private final int readTimeout;
+    private final int timeoutMilliseconds;
 
     @Override
     public String scrap(String productUrl) {
         try {
             return Jsoup.connect(productUrl)
-                    .timeout(readTimeout)
+                    .timeout(timeoutMilliseconds)
                     .header("Accept-Language", "en-US,en;q=0.9,ko;q=0.8")
                     .get()
                     .html();

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/controller/OfferingMemberController.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/controller/OfferingMemberController.java
@@ -2,6 +2,7 @@ package com.zzang.chongdae.offeringmember.controller;
 
 import com.zzang.chongdae.offeringmember.service.OfferingMemberService;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
+import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +18,7 @@ public class OfferingMemberController {
 
     @PostMapping("/participations")
     ResponseEntity<Void> participate(
-            @RequestBody ParticipationRequest request) {
+            @RequestBody @Valid ParticipationRequest request) {
         Long id = offeringMemberService.participate(request);
         return ResponseEntity.created(URI.create("/participations/" + id)).build();
     }

--- a/backend/src/test/java/com/zzang/chongdae/comment/integration/CommentIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/comment/integration/CommentIntegrationTest.java
@@ -9,13 +9,13 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ParameterDescriptorWithType;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.zzang.chongdae.comment.service.dto.CommentSaveRequest;
 import com.zzang.chongdae.global.integration.IntegrationTest;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -39,6 +39,7 @@ public class CommentIntegrationTest extends IntegrationTest {
                 .requestFields(saveCommentRequestDescriptors)
                 .requestSchema(schema("CommentSaveRequest"))
                 .build();
+
         MemberEntity member;
         OfferingEntity offering;
 
@@ -51,10 +52,10 @@ public class CommentIntegrationTest extends IntegrationTest {
         @DisplayName("댓글을 작성할 수 있다")
         @Test
         void should_saveCommentSuccess_when_givenCommentSaveRequest() {
-            Map<String, String> request = Map.of(
-                    "memberId", member.getId().toString(),
-                    "offeringId", offering.getId().toString(),
-                    "content", "댓글 내용"
+            CommentSaveRequest request = new CommentSaveRequest(
+                    member.getId(),
+                    offering.getId(),
+                    "댓글 내용"
             );
 
             RestAssured.given(spec).log().all()
@@ -65,6 +66,78 @@ public class CommentIntegrationTest extends IntegrationTest {
                     .then().log().all()
                     .statusCode(200);
         }
+
+        @DisplayName("요청 값에 빈값이 들어오는 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_emptyValue() {
+            CommentSaveRequest request = new CommentSaveRequest(
+                    null,
+                    null,
+                    ""
+            );
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("save-comment-fail-request-with-null", resource(snippets)))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().post("/comments")
+                    .then().log().all()
+                    .statusCode(400);
+        }
+
+        @DisplayName("요청 받은 내용의 길이가 80이 넘어가는 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_longContent() {
+            CommentSaveRequest request = new CommentSaveRequest(
+                    member.getId(),
+                    offering.getId(),
+                    "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+            );
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("save-comment-fail-request-with-long-content", resource(snippets)))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().post("/comments")
+                    .then().log().all()
+                    .statusCode(400);
+        }
+
+        @DisplayName("유효하지 않은 사용자에 대해 작성을 시도하는 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_invalidMember() {
+            CommentSaveRequest request = new CommentSaveRequest(
+                    member.getId() + 100,
+                    offering.getId(),
+                    "댓글 내용"
+            );
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("save-comment-fail-invalid_member", resource(snippets)))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().post("/comments")
+                    .then().log().all()
+                    .statusCode(400);
+        }
+
+        @DisplayName("유효하지 않은 공모에 대해 작성을 시도하는 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_invalidOffering() {
+            CommentSaveRequest request = new CommentSaveRequest(
+                    member.getId(),
+                    offering.getId() + 100,
+                    "댓글 내용"
+            );
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("save-comment-fail-invalid-offering", resource(snippets)))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().post("/comments")
+                    .then().log().all()
+                    .statusCode(400);
+        }
     }
 
     @DisplayName("댓글방 목록 조회")
@@ -74,20 +147,28 @@ public class CommentIntegrationTest extends IntegrationTest {
         List<ParameterDescriptorWithType> getAllCommentRoomQueryParameterDescriptors = List.of(
                 parameterWithName("member-id").description("회원 id")
         );
-        List<FieldDescriptor> getAllCommentRoomResponseDescriptors = List.of(
+        List<FieldDescriptor> getAllCommentRoomSuccessResponseDescriptors = List.of(
                 fieldWithPath("offerings[].offeringId").description("공모 id"),
                 fieldWithPath("offerings[].offeringTitle").description("공모 제목"),
                 fieldWithPath("offerings[].latestComment.content").description("최신 댓글 내용"),
                 fieldWithPath("offerings[].latestComment.createdAt").description("최신 댓글 작성일"),
                 fieldWithPath("offerings[].isProposer").description("총대 여부")
         );
-        ResourceSnippetParameters snippets = builder()
+        ResourceSnippetParameters successSnippets = builder()
                 .summary("댓글방 목록 조회")
                 .description("댓글방 목록을 조회합니다.")
                 .queryParameters(getAllCommentRoomQueryParameterDescriptors)
-                .responseFields(getAllCommentRoomResponseDescriptors)
+                .responseFields(getAllCommentRoomSuccessResponseDescriptors)
                 .responseSchema(schema("CommentRoomAllResponse"))
                 .build();
+        ResourceSnippetParameters failSnippets = builder()
+                .summary("댓글 목록 조회")
+                .description("댓글 목록을 조회합니다.")
+                .queryParameters(getAllCommentRoomQueryParameterDescriptors)
+                .responseFields(failResponseDescriptors)
+                .responseSchema(schema("CommentAllResponse"))
+                .build();
+
         MemberEntity member;
         OfferingEntity offering;
 
@@ -105,11 +186,22 @@ public class CommentIntegrationTest extends IntegrationTest {
         @Test
         void should_responseAllCommentRoom_when_givenMemberId() {
             RestAssured.given(spec).log().all()
-                    .filter(document("get-all-comment-room-success", resource(snippets)))
+                    .filter(document("get-all-comment-room-success", resource(successSnippets)))
                     .queryParam("member-id", member.getId())
                     .when().get("/comments")
                     .then().log().all()
                     .statusCode(200);
+        }
+
+        @DisplayName("유효하지 않는 사용자가 댓글방을 조회 할 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_invalidMember() {
+            RestAssured.given(spec).log().all()
+                    .filter(document("get-all-comment-room-fail-invalid-member", resource(failSnippets)))
+                    .queryParam("member-id", member.getId() + 100)
+                    .when().get("/comments")
+                    .then().log().all()
+                    .statusCode(400);
         }
     }
 
@@ -123,7 +215,7 @@ public class CommentIntegrationTest extends IntegrationTest {
         List<ParameterDescriptorWithType> getAllCommentQueryParameterDescriptors = List.of(
                 parameterWithName("member-id").description("회원 id")
         );
-        List<FieldDescriptor> getAllCommentResponseDescriptors = List.of(
+        List<FieldDescriptor> getAllCommentSuccessResponseDescriptors = List.of(
                 fieldWithPath("comments[].commentId").description("댓글 id"),
                 fieldWithPath("comments[].createdAt.date").description("작성 날짜"),
                 fieldWithPath("comments[].createdAt.time").description("작성 시간"),
@@ -132,12 +224,20 @@ public class CommentIntegrationTest extends IntegrationTest {
                 fieldWithPath("comments[].isProposer").description("총대 여부"),
                 fieldWithPath("comments[].isMine").description("내 댓글 여부")
         );
-        ResourceSnippetParameters snippets = builder()
+        ResourceSnippetParameters successSnippets = builder()
                 .summary("댓글 목록 조회")
                 .description("댓글 목록을 조회합니다.")
                 .pathParameters(getAllCommentPathParameterDescriptors)
                 .queryParameters(getAllCommentQueryParameterDescriptors)
-                .responseFields(getAllCommentResponseDescriptors)
+                .responseFields(getAllCommentSuccessResponseDescriptors)
+                .responseSchema(schema("CommentAllResponse"))
+                .build();
+        ResourceSnippetParameters failSnippets = builder()
+                .summary("댓글 목록 조회")
+                .description("댓글 목록을 조회합니다.")
+                .pathParameters(getAllCommentPathParameterDescriptors)
+                .queryParameters(getAllCommentQueryParameterDescriptors)
+                .responseFields(failResponseDescriptors)
                 .responseSchema(schema("CommentAllResponse"))
                 .build();
         MemberEntity member;
@@ -155,12 +255,24 @@ public class CommentIntegrationTest extends IntegrationTest {
         @Test
         void should_responseAllComment_when_givenOfferingIdAndMemberId() {
             RestAssured.given(spec).log().all()
-                    .filter(document("get-all-comment-success", resource(snippets)))
+                    .filter(document("get-all-comment-success", resource(successSnippets)))
                     .pathParam("offering-id", offering.getId())
                     .queryParam("member-id", member.getId())
                     .when().get("/comments/{offering-id}")
                     .then().log().all()
                     .statusCode(200);
+        }
+
+        @DisplayName("유효하지 않은 공모에 대해 댓글을 조회할 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_invalidOffering() {
+            RestAssured.given(spec).log().all()
+                    .filter(document("get-all-comment-fail-invalid-offering", resource(failSnippets)))
+                    .pathParam("offering-id", offering.getId() + 100)
+                    .queryParam("member-id", member.getId())
+                    .when().get("/comments/{offering-id}")
+                    .then().log().all()
+                    .statusCode(400);
         }
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/comment/integration/CommentIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/comment/integration/CommentIntegrationTest.java
@@ -28,16 +28,24 @@ public class CommentIntegrationTest extends IntegrationTest {
     @Nested
     class SaveComment {
 
-        List<FieldDescriptor> saveCommentRequestDescriptors = List.of(
+        List<FieldDescriptor> requestDescriptors = List.of(
                 fieldWithPath("memberId").description("회원 id"),
                 fieldWithPath("offeringId").description("공모 id"),
                 fieldWithPath("content").description("내용")
         );
-        ResourceSnippetParameters snippets = builder()
+        ResourceSnippetParameters successSnippets = builder()
                 .summary("댓글 작성")
                 .description("댓글을 작성합니다.")
-                .requestFields(saveCommentRequestDescriptors)
+                .requestFields(requestDescriptors)
                 .requestSchema(schema("CommentSaveRequest"))
+                .build();
+        ResourceSnippetParameters failSnippets = builder()
+                .summary("댓글 작성")
+                .description("댓글을 작성합니다.")
+                .requestFields(requestDescriptors)
+                .responseFields(failResponseDescriptors)
+                .requestSchema(schema("CommentSaveRequest"))
+                .responseSchema(schema("CommentSaveFailResponse"))
                 .build();
 
         MemberEntity member;
@@ -59,7 +67,7 @@ public class CommentIntegrationTest extends IntegrationTest {
             );
 
             RestAssured.given(spec).log().all()
-                    .filter(document("save-comment-success", resource(snippets)))
+                    .filter(document("save-comment-success", resource(successSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/comments")
@@ -77,7 +85,7 @@ public class CommentIntegrationTest extends IntegrationTest {
             );
 
             RestAssured.given(spec).log().all()
-                    .filter(document("save-comment-fail-request-with-null", resource(snippets)))
+                    .filter(document("save-comment-fail-request-with-null", resource(failSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/comments")
@@ -95,7 +103,7 @@ public class CommentIntegrationTest extends IntegrationTest {
             );
 
             RestAssured.given(spec).log().all()
-                    .filter(document("save-comment-fail-request-with-long-content", resource(snippets)))
+                    .filter(document("save-comment-fail-request-with-long-content", resource(failSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/comments")
@@ -113,7 +121,7 @@ public class CommentIntegrationTest extends IntegrationTest {
             );
 
             RestAssured.given(spec).log().all()
-                    .filter(document("save-comment-fail-invalid_member", resource(snippets)))
+                    .filter(document("save-comment-fail-invalid_member", resource(failSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/comments")
@@ -131,7 +139,7 @@ public class CommentIntegrationTest extends IntegrationTest {
             );
 
             RestAssured.given(spec).log().all()
-                    .filter(document("save-comment-fail-invalid-offering", resource(snippets)))
+                    .filter(document("save-comment-fail-invalid-offering", resource(failSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/comments")
@@ -144,10 +152,10 @@ public class CommentIntegrationTest extends IntegrationTest {
     @Nested
     class GetAllCommentRoom {
 
-        List<ParameterDescriptorWithType> getAllCommentRoomQueryParameterDescriptors = List.of(
+        List<ParameterDescriptorWithType> queryParameterDescriptors = List.of(
                 parameterWithName("member-id").description("회원 id")
         );
-        List<FieldDescriptor> getAllCommentRoomSuccessResponseDescriptors = List.of(
+        List<FieldDescriptor> successResponseDescriptors = List.of(
                 fieldWithPath("offerings[].offeringId").description("공모 id"),
                 fieldWithPath("offerings[].offeringTitle").description("공모 제목"),
                 fieldWithPath("offerings[].latestComment.content").description("최신 댓글 내용"),
@@ -157,16 +165,16 @@ public class CommentIntegrationTest extends IntegrationTest {
         ResourceSnippetParameters successSnippets = builder()
                 .summary("댓글방 목록 조회")
                 .description("댓글방 목록을 조회합니다.")
-                .queryParameters(getAllCommentRoomQueryParameterDescriptors)
-                .responseFields(getAllCommentRoomSuccessResponseDescriptors)
-                .responseSchema(schema("CommentRoomAllResponse"))
+                .queryParameters(queryParameterDescriptors)
+                .responseFields(successResponseDescriptors)
+                .responseSchema(schema("CommentRoomAllSuccessResponse"))
                 .build();
         ResourceSnippetParameters failSnippets = builder()
                 .summary("댓글 목록 조회")
                 .description("댓글 목록을 조회합니다.")
-                .queryParameters(getAllCommentRoomQueryParameterDescriptors)
+                .queryParameters(queryParameterDescriptors)
                 .responseFields(failResponseDescriptors)
-                .responseSchema(schema("CommentAllResponse"))
+                .responseSchema(schema("CommentRoomAllFailResponse"))
                 .build();
 
         MemberEntity member;
@@ -209,13 +217,13 @@ public class CommentIntegrationTest extends IntegrationTest {
     @Nested
     class GetAllComment {
 
-        List<ParameterDescriptorWithType> getAllCommentPathParameterDescriptors = List.of(
+        List<ParameterDescriptorWithType> pathParameterDescriptors = List.of(
                 parameterWithName("offering-id").description("공모 id")
         );
-        List<ParameterDescriptorWithType> getAllCommentQueryParameterDescriptors = List.of(
+        List<ParameterDescriptorWithType> queryParameterDescriptors = List.of(
                 parameterWithName("member-id").description("회원 id")
         );
-        List<FieldDescriptor> getAllCommentSuccessResponseDescriptors = List.of(
+        List<FieldDescriptor> successResponseDescriptors = List.of(
                 fieldWithPath("comments[].commentId").description("댓글 id"),
                 fieldWithPath("comments[].createdAt.date").description("작성 날짜"),
                 fieldWithPath("comments[].createdAt.time").description("작성 시간"),
@@ -227,18 +235,18 @@ public class CommentIntegrationTest extends IntegrationTest {
         ResourceSnippetParameters successSnippets = builder()
                 .summary("댓글 목록 조회")
                 .description("댓글 목록을 조회합니다.")
-                .pathParameters(getAllCommentPathParameterDescriptors)
-                .queryParameters(getAllCommentQueryParameterDescriptors)
-                .responseFields(getAllCommentSuccessResponseDescriptors)
-                .responseSchema(schema("CommentAllResponse"))
+                .pathParameters(pathParameterDescriptors)
+                .queryParameters(queryParameterDescriptors)
+                .responseFields(successResponseDescriptors)
+                .responseSchema(schema("CommentAllSuccessResponse"))
                 .build();
         ResourceSnippetParameters failSnippets = builder()
                 .summary("댓글 목록 조회")
                 .description("댓글 목록을 조회합니다.")
-                .pathParameters(getAllCommentPathParameterDescriptors)
-                .queryParameters(getAllCommentQueryParameterDescriptors)
+                .pathParameters(pathParameterDescriptors)
+                .queryParameters(queryParameterDescriptors)
                 .responseFields(failResponseDescriptors)
-                .responseSchema(schema("CommentAllResponse"))
+                .responseSchema(schema("CommentAllFailResponse"))
                 .build();
         MemberEntity member;
         OfferingEntity offering;

--- a/backend/src/test/java/com/zzang/chongdae/global/integration/IntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/global/integration/IntegrationTest.java
@@ -2,6 +2,7 @@ package com.zzang.chongdae.global.integration;
 
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
 
 import com.zzang.chongdae.global.domain.DomainSupplier;
@@ -10,6 +11,7 @@ import com.zzang.chongdae.offering.config.TestCrawlerConfig;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = {TestCrawlerConfig.class})
@@ -25,6 +28,9 @@ import org.springframework.test.context.ActiveProfiles;
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class IntegrationTest extends DomainSupplier {
 
+    protected final List<FieldDescriptor> failResponseDescriptors = List.of(
+            fieldWithPath("message").description("오류 내용")
+    );
     protected RequestSpecification spec;
     @Autowired
     protected DatabaseCleaner databaseCleaner;

--- a/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
@@ -310,6 +310,33 @@ public class OfferingIntegrationTest extends IntegrationTest {
                     .then().log().all()
                     .statusCode(400);
         }
+
+        @DisplayName("요청 값에 빈값이 들어오는 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_emptyValue() {
+            OfferingSaveRequest request = new OfferingSaveRequest(
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("create-offering-fail-request-with-null", resource(failSnippets)))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().post("/offerings")
+                    .then().log().all()
+                    .statusCode(400);
+        }
     }
 
     @DisplayName("상품 이미지 추출")
@@ -322,11 +349,19 @@ public class OfferingIntegrationTest extends IntegrationTest {
         List<FieldDescriptor> responseDescriptors = List.of(
                 fieldWithPath("imageUrl").description("이미지 url")
         );
-        ResourceSnippetParameters snippets = builder()
+        ResourceSnippetParameters successSnippets = builder()
                 .summary("상품 이미지 추출")
                 .description("상품 링크를 받아 이미지를 추출합니다.")
                 .requestFields(requestDescriptors)
                 .responseFields(responseDescriptors)
+                .requestSchema(schema("OfferingProductImageSuccessRequest"))
+                .responseSchema(schema("OfferingProductImageSuccessResponse"))
+                .build();
+        ResourceSnippetParameters failSnippets = builder()
+                .summary("상품 이미지 추출")
+                .description("상품 링크를 받아 이미지를 추출합니다.")
+                .requestFields(requestDescriptors)
+                .responseFields(failResponseDescriptors)
                 .requestSchema(schema("OfferingProductImageRequest"))
                 .responseSchema(schema("OfferingProductImageResponse"))
                 .build();
@@ -337,7 +372,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
             OfferingProductImageRequest request = new OfferingProductImageRequest("http://product-url.com");
 
             RestAssured.given(spec).log().all()
-                    .filter(document("extract-product-image-success", resource(snippets)))
+                    .filter(document("extract-product-image-success", resource(successSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/offerings/product-images/og")
@@ -351,12 +386,26 @@ public class OfferingIntegrationTest extends IntegrationTest {
             OfferingProductImageRequest request = new OfferingProductImageRequest("http://fail-product-url.com");
 
             RestAssured.given(spec).log().all()
-                    .filter(document("extract-product-image-fail", resource(snippets)))
+                    .filter(document("extract-product-image-fail", resource(successSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/offerings/product-images/og")
                     .then().log().all()
                     .statusCode(200);
+        }
+
+        @DisplayName("요청 값에 빈값이 들어오는 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_emptyValue() {
+            OfferingProductImageRequest request = new OfferingProductImageRequest(null);
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("extract-product-image-fail-request-with-null", resource(failSnippets)))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().post("/offerings/product-images/og")
+                    .then().log().all()
+                    .statusCode(400);
         }
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
@@ -29,13 +29,13 @@ public class OfferingIntegrationTest extends IntegrationTest {
     @Nested
     class GetOfferingDetail {
 
-        List<ParameterDescriptorWithType> offeringDetailPathParameterDescriptors = List.of(
+        List<ParameterDescriptorWithType> pathParameterDescriptors = List.of(
                 parameterWithName("offering-id").description("공모 id")
         );
-        List<ParameterDescriptorWithType> offeringDetailQueryParameterDescriptors = List.of(
+        List<ParameterDescriptorWithType> queryParameterDescriptors = List.of(
                 parameterWithName("member-id").description("회원 id")
         );
-        List<FieldDescriptor> offeringDetailSuccessResponseDescriptors = List.of(
+        List<FieldDescriptor> successResponseDescriptors = List.of(
                 fieldWithPath("id").description("공모 id"),
                 fieldWithPath("title").description("제목"),
                 fieldWithPath("productUrl").description("물품 링크"),
@@ -56,18 +56,18 @@ public class OfferingIntegrationTest extends IntegrationTest {
         ResourceSnippetParameters successSnippets = builder()
                 .summary("공모 상세 조회")
                 .description("공모 id를 통해 공모의 상세 정보를 조회합니다.")
-                .pathParameters(offeringDetailPathParameterDescriptors)
-                .queryParameters(offeringDetailQueryParameterDescriptors)
-                .responseFields(offeringDetailSuccessResponseDescriptors)
-                .responseSchema(schema("OfferingDetailResponse")) // TODO: change?
+                .pathParameters(pathParameterDescriptors)
+                .queryParameters(queryParameterDescriptors)
+                .responseFields(successResponseDescriptors)
+                .responseSchema(schema("OfferingDetailSuccessResponse"))
                 .build();
         ResourceSnippetParameters failSnippets = builder()
                 .summary("공모 상세 조회")
                 .description("공모 id를 통해 공모의 상세 정보를 조회합니다.")
-                .pathParameters(offeringDetailPathParameterDescriptors)
-                .queryParameters(offeringDetailQueryParameterDescriptors)
+                .pathParameters(pathParameterDescriptors)
+                .queryParameters(queryParameterDescriptors)
                 .responseFields(failResponseDescriptors)
-                .responseSchema(schema("OfferingDetailResponse"))
+                .responseSchema(schema("OfferingDetailFailResponse"))
                 .build();
 
         @BeforeEach
@@ -117,11 +117,11 @@ public class OfferingIntegrationTest extends IntegrationTest {
     @Nested
     class GetAllOffering {
 
-        List<ParameterDescriptorWithType> offeringAllQueryParameterDescriptors = List.of(
+        List<ParameterDescriptorWithType> queryParameterDescriptors = List.of(
                 parameterWithName("last-id").description("마지막 공모 id"),
                 parameterWithName("page-size").description("페이지 크기")
         );
-        List<FieldDescriptor> offeringAllResponseDescriptors = List.of(
+        List<FieldDescriptor> successResponseDescriptors = List.of(
                 fieldWithPath("offerings[].id").description("공모 id"),
                 fieldWithPath("offerings[].title").description("제목"),
                 fieldWithPath("offerings[].meetingAddressDong").description("모집 동 주소"),
@@ -132,12 +132,12 @@ public class OfferingIntegrationTest extends IntegrationTest {
                 fieldWithPath("offerings[].condition").description("공모 상태"),
                 fieldWithPath("offerings[].isOpen").description("공모 참여 가능 여부")
         );
-        ResourceSnippetParameters snippets = builder()
+        ResourceSnippetParameters successSnippets = builder()
                 .summary("공모 목록 조회")
                 .description("공모 목록을 조회합니다.")
-                .queryParameters(offeringAllQueryParameterDescriptors)
-                .responseFields(offeringAllResponseDescriptors)
-                .responseSchema(schema("OfferingAllResponse"))
+                .queryParameters(queryParameterDescriptors)
+                .responseFields(successResponseDescriptors)
+                .responseSchema(schema("OfferingAllSuccessResponse"))
                 .build();
 
         @BeforeEach
@@ -152,7 +152,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
         @Test
         void should_responseAllOffering_when_givenPageInfo() {
             RestAssured.given(spec).log().all()
-                    .filter(document("get-all-offering-success", resource(snippets)))
+                    .filter(document("get-all-offering-success", resource(successSnippets)))
                     .queryParam("last-id", 1)
                     .queryParam("page-size", 10)
                     .when().get("/offerings")
@@ -165,10 +165,10 @@ public class OfferingIntegrationTest extends IntegrationTest {
     @Nested
     class GetOfferingMeeting {
 
-        List<ParameterDescriptorWithType> offeringMeetingPathParameterDescriptors = List.of(
+        List<ParameterDescriptorWithType> pathParameterDescriptors = List.of(
                 parameterWithName("offering-id").description("공모 id")
         );
-        List<FieldDescriptor> offeringMeetingSuccessResponseDescriptors = List.of(
+        List<FieldDescriptor> successResponseDescriptors = List.of(
                 fieldWithPath("deadline").description("마감시간"),
                 fieldWithPath("meetingAddress").description("모집 주소"),
                 fieldWithPath("meetingAddressDetail").description("모집 상세 주소")
@@ -176,16 +176,16 @@ public class OfferingIntegrationTest extends IntegrationTest {
         ResourceSnippetParameters successSnippets = builder()
                 .summary("공모 일정 조회")
                 .description("공모 id를 통해 공모의 일정 정보를 조회합니다.")
-                .pathParameters(offeringMeetingPathParameterDescriptors)
-                .responseFields(offeringMeetingSuccessResponseDescriptors)
-                .responseSchema(schema("OfferingMeetingResponse"))
+                .pathParameters(pathParameterDescriptors)
+                .responseFields(successResponseDescriptors)
+                .responseSchema(schema("OfferingMeetingSuccessResponse"))
                 .build();
         ResourceSnippetParameters failSnippets = builder()
                 .summary("공모 일정 조회")
                 .description("공모 id를 통해 공모의 일정 정보를 조회합니다.")
-                .pathParameters(offeringMeetingPathParameterDescriptors)
+                .pathParameters(pathParameterDescriptors)
                 .responseFields(failResponseDescriptors)
-                .responseSchema(schema("OfferingMeetingResponse"))
+                .responseSchema(schema("OfferingMeetingFailResponse"))
                 .build();
 
         @BeforeEach
@@ -221,7 +221,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
     @Nested
     class CreateOffering {
 
-        List<FieldDescriptor> offeringCreateRequestDescriptors = List.of(
+        List<FieldDescriptor> requestDescriptors = List.of(
                 fieldWithPath("memberId").description("회원 id"),
                 fieldWithPath("title").description("제목"),
                 fieldWithPath("productUrl").description("물품 구매 링크"),
@@ -238,15 +238,16 @@ public class OfferingIntegrationTest extends IntegrationTest {
         ResourceSnippetParameters successSnippets = builder()
                 .summary("공모 작성")
                 .description("공모 정보를 받아 공모를 작성합니다.")
-                .requestFields(offeringCreateRequestDescriptors)
-                .responseSchema(schema("OfferingCreateResponse"))
+                .requestFields(requestDescriptors)
+                .requestSchema(schema("OfferingCreateRequest"))
                 .build();
         ResourceSnippetParameters failSnippets = builder()
                 .summary("공모 작성")
                 .description("공모 정보를 받아 공모를 작성합니다.")
-                .requestFields(offeringCreateRequestDescriptors)
+                .requestFields(requestDescriptors)
                 .responseFields(failResponseDescriptors)
-                .responseSchema(schema("OfferingCreateResponse"))
+                .requestSchema(schema("OfferingCreateRequest"))
+                .responseSchema(schema("OfferingCreateFailResponse"))
                 .build();
 
         MemberEntity member;
@@ -315,13 +316,18 @@ public class OfferingIntegrationTest extends IntegrationTest {
     @Nested
     class ExtractProductImage {
 
-        List<FieldDescriptor> offeringProductImageSuccessRequestDescriptors = List.of(
+        List<FieldDescriptor> requestDescriptors = List.of(
                 fieldWithPath("productUrl").description("상품 url")
         );
-        ResourceSnippetParameters successSnippets = builder()
+        List<FieldDescriptor> responseDescriptors = List.of(
+                fieldWithPath("imageUrl").description("이미지 url")
+        );
+        ResourceSnippetParameters snippets = builder()
                 .summary("상품 이미지 추출")
                 .description("상품 링크를 받아 이미지를 추출합니다.")
-                .requestFields(offeringProductImageSuccessRequestDescriptors)
+                .requestFields(requestDescriptors)
+                .responseFields(responseDescriptors)
+                .requestSchema(schema("OfferingProductImageRequest"))
                 .responseSchema(schema("OfferingProductImageResponse"))
                 .build();
 
@@ -331,7 +337,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
             OfferingProductImageRequest request = new OfferingProductImageRequest("http://product-url.com");
 
             RestAssured.given(spec).log().all()
-                    .filter(document("extract-product-image-success", resource(successSnippets)))
+                    .filter(document("extract-product-image-success", resource(snippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/offerings/product-images/og")
@@ -345,7 +351,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
             OfferingProductImageRequest request = new OfferingProductImageRequest("http://fail-product-url.com");
 
             RestAssured.given(spec).log().all()
-                    .filter(document("extract-product-image-fail", resource(successSnippets)))
+                    .filter(document("extract-product-image-fail", resource(snippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/offerings/product-images/og")

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
@@ -118,5 +118,21 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
                     .then().log().all()
                     .statusCode(400);
         }
+
+        @DisplayName("요청 값에 빈값이 들어오는 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_emptyValue() {
+            ParticipationRequest request = new ParticipationRequest(
+                    null,
+                    null
+            );
+            RestAssured.given(spec).log().all()
+                    .filter(document("participate-fail-request-with-null", resource(failSnippets)))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().post("/participations")
+                    .then().log().all()
+                    .statusCode(400);
+        }
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
@@ -25,22 +25,23 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
     @Nested
     class Participate {
 
-        List<FieldDescriptor> participationRequestDescriptors = List.of(
+        List<FieldDescriptor> requestDescriptors = List.of(
                 fieldWithPath("memberId").description("회원 id"),
                 fieldWithPath("offeringId").description("공모 id")
         );
-        ResourceSnippetParameters snippets = ResourceSnippetParameters.builder()
+        ResourceSnippetParameters successSnippets = ResourceSnippetParameters.builder()
                 .summary("공모 참여")
                 .description("게시된 공모에 참여합니다.")
-                .requestFields(participationRequestDescriptors)
-                .requestSchema(schema("ParticipationRequest"))
+                .requestFields(requestDescriptors)
+                .requestSchema(schema("ParticipationSuccessRequest"))
                 .build();
         ResourceSnippetParameters failSnippets = ResourceSnippetParameters.builder()
                 .summary("공모 참여")
                 .description("게시된 공모에 참여합니다.")
-                .requestFields(participationRequestDescriptors)
+                .requestFields(requestDescriptors)
                 .responseFields(failResponseDescriptors)
-                .requestSchema(schema("ParticipationRequest"))
+                .requestSchema(schema("ParticipationFailRequest"))
+                .responseSchema(schema("ParticipationSuccessResponse"))
                 .build();
         MemberEntity proposer;
         MemberEntity participant;
@@ -57,10 +58,12 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
         @DisplayName("게시된 공모에 참여할 수 있다")
         @Test
         void should_participateSuccess() {
-            ParticipationRequest request = new ParticipationRequest(participant.getId(), offering.getId());
-
+            ParticipationRequest request = new ParticipationRequest(
+                    participant.getId(),
+                    offering.getId()
+            );
             RestAssured.given(spec).log().all()
-                    .filter(document("participate-success", resource(snippets)))
+                    .filter(document("participate-success", resource(successSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/participations")
@@ -71,10 +74,12 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
         @DisplayName("공모자는 본인이 만든 공모에 참여할 수 없다")
         @Test
         void should_throwException_when_givenProposerParticipate() {
-            ParticipationRequest request = new ParticipationRequest(proposer.getId(), offering.getId());
-
+            ParticipationRequest request = new ParticipationRequest(
+                    proposer.getId(),
+                    offering.getId()
+            );
             RestAssured.given(spec).log().all()
-                    .filter(document("participate-fail", resource(snippets)))
+                    .filter(document("participate-fail-my-offering", resource(failSnippets)))
                     .contentType(ContentType.JSON)
                     .body(request)
                     .when().post("/participations")
@@ -85,8 +90,10 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
         @DisplayName("유효하지 않은 사용자가 공모에 참여할 경우 예외가 발생한다.")
         @Test
         void should_throwException_when_invalidMember() {
-            ParticipationRequest request = new ParticipationRequest(participant.getId() + 100, offering.getId());
-
+            ParticipationRequest request = new ParticipationRequest(
+                    participant.getId() + 100,
+                    offering.getId()
+            );
             RestAssured.given(spec).log().all()
                     .filter(document("participate-fail-invalid-member", resource(failSnippets)))
                     .contentType(ContentType.JSON)
@@ -99,8 +106,10 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
         @DisplayName("유효하지 않은 공모에 참여할 경우 예외가 발생한다.")
         @Test
         void should_throwException_when_invalidOffering() {
-            ParticipationRequest request = new ParticipationRequest(participant.getId(), offering.getId() + 100);
-
+            ParticipationRequest request = new ParticipationRequest(
+                    participant.getId(),
+                    offering.getId() + 100
+            );
             RestAssured.given(spec).log().all()
                     .filter(document("participate-fail-invalid-offering", resource(failSnippets)))
                     .contentType(ContentType.JSON)


### PR DESCRIPTION
## 📌 관련 이슈
close #151
## ✨ 작업 내용
- 테스트 request 형태를 Map에서 DTO로 변경
- 문서화 description 내 optional 정보 추가
- 예외 처리에 대한 문서화
## 📚 기타
### 코드 내 변경사항
- 가독성 향상을 위해 `내부클래스명 + requestDescriptors`, `내부클래스명 + successSnippets` 등과 같이 사용하던 변수명을 `requestDescriptors`, `successSnippets` 등으로 통일.