### PR TITLE
feat: 주소검색 기능구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -141,4 +141,7 @@ dependencies {
 
     // Pagination
     implementation("androidx.paging:paging-runtime-ktx:3.3.0")
+
+    // WebView
+    implementation("androidx.webkit:webkit:1.9.0")
 }

--- a/android/app/src/main/assets/html/address.html
+++ b/android/app/src/main/assets/html/address.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <script type="text/javascript">
+        const BRIDGE_CODE = "address_finder";
+
+        function send(address, zipCode){
+            window[BRIDGE_CODE].result(address); // 파라미터에서 우편번호는 제외시킴
+        }
+    </script>
+    <style>
+        html, body { width: 100%; height: 100%; background: #ffffff; padding: 0; margin: 0; }
+        div#layer { width: 100%; height: 100%; }
+    </style>
+</head>
+<body onload="load()">
+<div id="layer"
+     style="display:block;position:fixed;overflow:hidden;z-index:1;-webkit-overflow-scrolling:touch;"></div>
+
+<script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+<script>
+    // 우편번호 찾기 화면을 넣을 element
+    const el = document.getElementById('layer');
+
+    function load() {
+        new daum.Postcode({
+            oncomplete: function(data) {
+                let fullRoadAddr = data.roadAddress; // 도로명 주소 변수
+                let extraRoadAddr = ''; // 도로명 조합형 주소 변수
+
+                // 법정동명이 있을 경우 추가한다. (법정리는 제외)
+                // 법정동의 경우 마지막 문자가 "동/로/가"로 끝난다.
+                if(data.bname.length > 0 && /[동|로|가]$/g.test(data.bname))
+                    extraRoadAddr += data.bname;
+
+                // 건물명이 있고, 공동주택일 경우 추가한다.
+                if(data.buildingName.length > 0 && data.apartment === 'Y')
+                   extraRoadAddr += (extraRoadAddr !== '' ? ', ' + data.buildingName : data.buildingName);
+
+                // 도로명, 지번 조합형 주소가 있을 경우, 괄호까지 추가한 최종 문자열을 만든다.
+                if(extraRoadAddr.length > 0) extraRoadAddr = ' (' + extraRoadAddr + ')';
+
+                // 도로명, 지번 주소의 유무에 따라 해당 조합형 주소를 추가한다.
+                if(fullRoadAddr.length > 0) fullRoadAddr += extraRoadAddr;
+
+                send(fullRoadAddr, data.zonecode);
+            },
+            width : '100%',
+            height : '100%'
+        }).embed(el);
+    }
+
+    window.addEventListener('orientationchange', () => {
+        load();
+    })
+</script>
+</body>
+</html>
+

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/AddressFinderDialog.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/AddressFinderDialog.kt
@@ -1,0 +1,85 @@
+package com.zzang.chongdae.presentation.view.address
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import androidx.webkit.WebViewAssetLoader
+import com.zzang.chongdae.databinding.DialogAddressFinderBinding
+
+class AddressFinderDialog : DialogFragment(), OnAddressClickListener {
+    private var _binding: DialogAddressFinderBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogAddressFinderBinding.inflate(inflater, container, false)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initDialog()
+        initWebView()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun initDialog() {
+        dialog?.window?.apply {
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun initWebView() {
+        val assetLoader = webViewAssetLoader()
+
+        binding.wvAddress.run {
+            with(settings) {
+                javaScriptEnabled = true
+                allowFileAccess = false
+                allowContentAccess = false
+            }
+            addJavascriptInterface(
+                JavascriptInterface(this@AddressFinderDialog),
+                JS_BRIDGE
+            )
+            webViewClient = AddressWebViewClient(assetLoader)
+            loadUrl("https://${DOMAIN}/${PATH}/html/address.html")
+        }
+    }
+
+    private fun webViewAssetLoader() = WebViewAssetLoader.Builder()
+        .addPathHandler(
+            "/${PATH}/",
+            WebViewAssetLoader.AssetsPathHandler(requireContext())
+        )
+        .setDomain(DOMAIN)
+        .build()
+
+    override fun onClickAddress(address: String) {
+        setFragmentResult(ADDRESS_KEY, bundleOf(BUNDLE_ADDRESS_KEY to address))
+        dismiss()
+    }
+
+    companion object {
+        private const val JS_BRIDGE = "address_finder"
+        private const val DOMAIN = "address.finder.net"
+        private const val PATH = "assets"
+
+        const val ADDRESS_KEY = "address_key"
+        const val BUNDLE_ADDRESS_KEY = "address"
+    }
+}

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/AddressFinderDialog.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/AddressFinderDialog.kt
@@ -16,15 +16,19 @@ class AddressFinderDialog : DialogFragment(), OnAddressClickListener {
     private val binding get() = _binding!!
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
     ): View {
         _binding = DialogAddressFinderBinding.inflate(inflater, container, false)
 
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         super.onViewCreated(view, savedInstanceState)
 
         initDialog()
@@ -54,20 +58,21 @@ class AddressFinderDialog : DialogFragment(), OnAddressClickListener {
             }
             addJavascriptInterface(
                 JavascriptInterface(this@AddressFinderDialog),
-                JS_BRIDGE
+                JS_BRIDGE,
             )
             webViewClient = AddressWebViewClient(assetLoader)
-            loadUrl("https://${DOMAIN}/${PATH}/html/address.html")
+            loadUrl("https://$DOMAIN/$PATH/html/address.html")
         }
     }
 
-    private fun webViewAssetLoader() = WebViewAssetLoader.Builder()
-        .addPathHandler(
-            "/${PATH}/",
-            WebViewAssetLoader.AssetsPathHandler(requireContext())
-        )
-        .setDomain(DOMAIN)
-        .build()
+    private fun webViewAssetLoader() =
+        WebViewAssetLoader.Builder()
+            .addPathHandler(
+                "/$PATH/",
+                WebViewAssetLoader.AssetsPathHandler(requireContext()),
+            )
+            .setDomain(DOMAIN)
+            .build()
 
     override fun onClickAddress(address: String) {
         setFragmentResult(ADDRESS_KEY, bundleOf(BUNDLE_ADDRESS_KEY to address))

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/AddressWebViewClient.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/AddressWebViewClient.kt
@@ -10,7 +10,7 @@ class AddressWebViewClient(private val assetLoader: WebViewAssetLoader) :
     WebViewClientCompat() {
     override fun shouldInterceptRequest(
         view: WebView?,
-        request: WebResourceRequest?
+        request: WebResourceRequest?,
     ): WebResourceResponse? {
         return assetLoader.shouldInterceptRequest(request!!.url)
     }

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/AddressWebViewClient.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/AddressWebViewClient.kt
@@ -1,0 +1,17 @@
+package com.zzang.chongdae.presentation.view.address
+
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.webkit.WebViewAssetLoader
+import androidx.webkit.WebViewClientCompat
+
+class AddressWebViewClient(private val assetLoader: WebViewAssetLoader) :
+    WebViewClientCompat() {
+    override fun shouldInterceptRequest(
+        view: WebView?,
+        request: WebResourceRequest?
+    ): WebResourceResponse? {
+        return assetLoader.shouldInterceptRequest(request!!.url)
+    }
+}

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/JavascriptInterface.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/JavascriptInterface.kt
@@ -1,0 +1,12 @@
+package com.zzang.chongdae.presentation.view.address
+
+import android.os.Looper
+
+class JavascriptInterface(private val onAddressClickListener: OnAddressClickListener) {
+    @android.webkit.JavascriptInterface
+    fun result(address: String) {
+        android.os.Handler(Looper.getMainLooper()).post {
+            onAddressClickListener.onClickAddress(address)
+        }
+    }
+}

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/OnAddressClickListener.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/address/OnAddressClickListener.kt
@@ -1,0 +1,5 @@
+package com.zzang.chongdae.presentation.view.address
+
+interface OnAddressClickListener {
+    fun onClickAddress(address: String)
+}

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/HomeFragment.kt
@@ -16,7 +16,7 @@ import com.zzang.chongdae.databinding.FragmentHomeBinding
 import com.zzang.chongdae.presentation.view.home.adapter.OfferingAdapter
 import com.zzang.chongdae.presentation.view.offeringdetail.OfferingDetailActivity
 
-class HomeFragment : Fragment(), OnArticleClickListener {
+class HomeFragment : Fragment(), OnOfferingClickListener {
     private var _binding: FragmentHomeBinding? = null
     private val binding get() = _binding!!
     private lateinit var offeringAdapter: OfferingAdapter

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/OnOfferingClickListener.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/OnOfferingClickListener.kt
@@ -1,5 +1,5 @@
 package com.zzang.chongdae.presentation.view.home
 
-interface OnArticleClickListener {
+interface OnOfferingClickListener {
     fun onClick(offeringId: Long)
 }

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/adapter/OfferingAdapter.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/adapter/OfferingAdapter.kt
@@ -6,10 +6,10 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import com.zzang.chongdae.databinding.ItemOfferingBinding
 import com.zzang.chongdae.domain.model.Offering
-import com.zzang.chongdae.presentation.view.home.OnArticleClickListener
+import com.zzang.chongdae.presentation.view.home.OnOfferingClickListener
 
 class OfferingAdapter(
-    private val onArticleClickListener: OnArticleClickListener,
+    private val onOfferingClickListener: OnOfferingClickListener,
 ) : PagingDataAdapter<Offering, OfferingViewHolder>(productComparator) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -24,7 +24,7 @@ class OfferingAdapter(
         holder: OfferingViewHolder,
         position: Int,
     ) {
-        getItem(position)?.let { holder.bind(it, onArticleClickListener) }
+        getItem(position)?.let { holder.bind(it, onOfferingClickListener) }
     }
 
     companion object {

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/adapter/OfferingViewHolder.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/adapter/OfferingViewHolder.kt
@@ -3,16 +3,16 @@ package com.zzang.chongdae.presentation.view.home.adapter
 import androidx.recyclerview.widget.RecyclerView
 import com.zzang.chongdae.databinding.ItemOfferingBinding
 import com.zzang.chongdae.domain.model.Offering
-import com.zzang.chongdae.presentation.view.home.OnArticleClickListener
+import com.zzang.chongdae.presentation.view.home.OnOfferingClickListener
 
 class OfferingViewHolder(
     private val binding: ItemOfferingBinding,
 ) : RecyclerView.ViewHolder(binding.root) {
     fun bind(
         offering: Offering,
-        onArticleClickListener: OnArticleClickListener,
+        onOfferingClickListener: OnOfferingClickListener,
     ) {
         binding.offering = offering
-        binding.onArticleClickListener = onArticleClickListener
+        binding.onArticleClickListener = onOfferingClickListener
     }
 }

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailViewModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 class OfferingDetailViewModel(
     private val offeringId: Long,
     private val offeringDetailRepository: OfferingDetailRepository,
-) : ViewModel(), ParticipationClickListener {
+) : ViewModel(), OnParticipationClickListener {
     private val _offeringDetail: MutableLiveData<OfferingDetail> = MutableLiveData()
     val offeringDetail: LiveData<OfferingDetail> get() = _offeringDetail
 

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OnParticipationClickListener.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OnParticipationClickListener.kt
@@ -1,5 +1,5 @@
 package com.zzang.chongdae.presentation.view.offeringdetail
 
-interface ParticipationClickListener {
+interface OnParticipationClickListener {
     fun onClickParticipation()
 }

--- a/android/app/src/main/res/layout/dialog_address_finder.xml
+++ b/android/app/src/main/res/layout/dialog_address_finder.xml
@@ -8,8 +8,7 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".TestDialogFragment">
+        android:layout_height="match_parent">
 
         <WebView
             android:id="@+id/wv_address"

--- a/android/app/src/main/res/layout/dialog_address_finder.xml
+++ b/android/app/src/main/res/layout/dialog_address_finder.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".TestDialogFragment">
+
+        <WebView
+            android:id="@+id/wv_address"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </FrameLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_offering.xml
+++ b/android/app/src/main/res/layout/item_offering.xml
@@ -12,7 +12,7 @@
 
         <variable
             name="onArticleClickListener"
-            type="com.zzang.chongdae.presentation.view.home.OnArticleClickListener" />
+            type="com.zzang.chongdae.presentation.view.home.OnOfferingClickListener" />
 
     </data>
 


### PR DESCRIPTION
## 📌 관련 이슈
close #159 
## ✨ 작업 내용
주소검색 api를 활용해 주소검색 다이얼로그를 구현하였습니다.

[사용법]

dataBinding같은 부분들을 제외하고 러프하게 작성한 사용 코드 예시입니다.
아래와 같이 클릭 리스너와 결과 데이터를 읽는 리스너 두가지만 설정해주시면 됩니다.
아마 사용 시 수정할 부분은 `etAddress` 대신에 직접 구현하신 주소검색창의 id로 변경 정도 일 것 같아요.

```
// 주소검색 다이얼로그가 뜨도록 리스너 달아줌
binding.etAddress.setOnClickListener { 
    AddressFinderDialog().show(parentFragmentManager, this.tag)
}

// 주소를 클릭했을 때 해당 데이터를 읽는 리스너 설정
setFragmentResultListener(AddressFinderDialog.ADDRESS_KEY) { _, bundle ->
    binding.etAddress.text = bundle.getString(AddressFinderDialog.BUNDLE_ADDRESS_KEY)
}
```

## 📚 기타


https://github.com/user-attachments/assets/9388d2de-ce75-4a14-af82-603e4ad855ed


