### PR TITLE
chore: 브랜치에 상관없이 pr 머지 시 자동으로 관련 이슈 닫는 스크립트 구현

### DIFF
--- a/.github/workflows/auto-issue-close.yml
+++ b/.github/workflows/auto-issue-close.yml
@@ -1,0 +1,20 @@
+name: Auto Close Issues on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close-related-issue:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.base.ref != 'main'
+    steps:
+      - name: Extract and Close Issue
+        run: |
+          PR_BODY="${{ github.event.pull_request.body }}"
+          ISSUE_NUMBERS=$(echo $PR_BODY | grep -oP 'close #\d+' | awk '{print substr($2, 2)}')
+          for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+            gh api -X PATCH /repos/${{ github.repository }}/issues/$ISSUE_NUMBER --field state=closed
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTO_CLOSE_GITHUB_TOKEN }}


### PR DESCRIPTION
## 📌 관련 이슈
close #185 
## ✨ 작업 내용
- 브랜치에 상관없이 pr 머지 시 자동으로 관련 이슈 닫는 스크립트 구현
## 📚 기타
- 개인 레포에서 똑같은 환경 조성해두고 잘 동작하는 것 확인했습니다!
[개인 레포 링크](https://github.com/ChooSeoyeon/github-action-workflow/issues/1)