### PR TITLE
fix: 원 가격이 없는 경우 n빵 가격을 비교하지 않도록 변경

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/domain/OfferingPrice.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/domain/OfferingPrice.java
@@ -27,7 +27,7 @@ public class OfferingPrice {
 
     public void validateOriginPrice() {
         int dividedPrice = totalPrice / totalCount;
-        if (originPrice < dividedPrice) {
+        if (originPrice != null && originPrice < dividedPrice) {
             throw new MarketException(OfferingErrorCode.CANNOT_ORIGIN_PRICE_LESS_THEN_DIVIDED_PRICE);
         }
     }

--- a/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
@@ -411,7 +411,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
             member = memberFixture.createMember();
         }
 
-        @DisplayName("공모 정보를 받아 공모를 작성합니다")
+        @DisplayName("공모 정보를 받아 공모를 작성 할 수 있다.")
         @Test
         void should_createOffering_when_givenOfferingCreateRequest() {
             OfferingSaveRequest request = new OfferingSaveRequest(

--- a/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
@@ -1,0 +1,45 @@
+package com.zzang.chongdae.offering.service;
+
+import com.zzang.chongdae.global.integration.IntegrationTest;
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.offering.service.dto.OfferingSaveRequest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+// TODO: service 테스트 환경도 IntegrationTest 동일하게 적용하지 않을 경우 data.sql 정보가 db에 저장됨
+public class OfferingServiceTest extends IntegrationTest {
+
+    @Autowired
+    OfferingService offeringService;
+
+    @DisplayName("공목 등록 시 원 가격 정보가 없더라도 공모 작성에 성공할 수 있다.")
+    @Test
+    void should_createOffering_when_givenOfferingWithoutOriginPriceCreateRequest() {
+
+        // given
+        MemberEntity member = memberFixture.createMember("pizza");
+        OfferingSaveRequest request = new OfferingSaveRequest(
+                "공모 제목",
+                "www.naver.com",
+                "www.naver.com/favicon.ico",
+                5,
+                10000,
+                null,
+                "서울특별시 광진구 구의강변로 3길 11",
+                "상세주소아파트",
+                "구의동",
+                LocalDateTime.parse("2024-10-11T10:00:00"),
+                "내용입니다."
+        );
+        Long expected = 1L;
+
+        // when
+        Long actual = offeringService.saveOffering(request, member);
+
+        // then
+        Assertions.assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
close #244 
## ✨ 작업 내용
- 원 가격이 없는 경우 n빵 가격을 비교하지 않도록 변경
## 📚 기타
