### PR TITLE
fix: 마감 임박 공모 조회 시 수동 마감 된 공고가 보이지 않도록 변경

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
@@ -36,6 +36,7 @@ public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> 
                 OR (o.totalCount <= 3 AND (o.totalCount - o.currentCount) < 2)
                 OR (o.totalCount > 3 AND (o.totalCount - o.currentCount) < 3))
             AND (:keyword IS NULL OR o.title LIKE %:keyword% OR o.meetingAddress LIKE %:keyword%)
+            AND (o.isManualConfirmed IS FALSE)
             ORDER BY o.deadline ASC, o.id DESC
             """)
     List<OfferingEntity> findImminentOfferingsWithKeyword(


### PR DESCRIPTION
## 📌 관련 이슈
close #265 
## ✨ 작업 내용
- 마감 임박 공모 조회 시 수동 마감 된 공고가 보이지 않도록 조치합니다
## 📚 기타
