### PR TITLE
fix: 이미지 업로드 API의 responseBody가 두 번 뜨는 오류 해결

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/logging/config/LoggingFilter.java
+++ b/backend/src/main/java/com/zzang/chongdae/logging/config/LoggingFilter.java
@@ -18,6 +18,7 @@ public class LoggingFilter implements Filter {
             throws IOException, ServletException {
         if (isMultipart(request)) {
             chain.doFilter(request, response);
+            return;
         }
         HttpServletRequest wrappedRequest
                 = new CachedHttpServletRequestWrapper((HttpServletRequest) request);

--- a/backend/src/main/java/com/zzang/chongdae/logging/config/LoggingInterceptor.java
+++ b/backend/src/main/java/com/zzang/chongdae/logging/config/LoggingInterceptor.java
@@ -28,6 +28,9 @@ public class LoggingInterceptor implements HandlerInterceptor {
                                 HttpServletResponse response,
                                 Object handler,
                                 Exception ex) throws IOException {
+        if (isMultipart(request)) {
+            return;
+        }
 
         long startTime = Long.parseLong(request.getAttribute("startTime").toString());
         long endTime = System.currentTimeMillis();
@@ -58,5 +61,10 @@ public class LoggingInterceptor implements HandlerInterceptor {
                     requestBody, statusCode, responseBody, latency);
             log.warn(logResponse.toString());
         }
+    }
+
+    private boolean isMultipart(HttpServletRequest request) {
+        String contentType = request.getContentType();
+        return contentType != null && contentType.toLowerCase().startsWith("multipart/");
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
@@ -690,6 +690,9 @@ public class OfferingIntegrationTest extends IntegrationTest {
     @Nested
     class UploadProductImage {
 
+        List<FieldDescriptor> responseDescriptors = List.of(
+                fieldWithPath("imageUrl").description("이미지 url")
+        );
         ResourceSnippetParameters successSnippets = builder()
                 .summary("상품 이미지 업로드")
                 .description("""
@@ -701,6 +704,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
                         |--------------|--------|------------------------|
                         | image        | binary | 상품 이미지               |
                         """)
+                .responseFields(responseDescriptors)
                 .responseSchema(schema("OfferingProductImageSuccessResponse"))
                 .build();
 


### PR DESCRIPTION
## 📌 관련 이슈
close #272 
## ✨ 작업 내용
- 이미지 업로드 API의 responseBody가 두 번 뜨는 오류 해결
## 📚 기타
- 추후에, 이미지 업로드에서 뜨는 에러 로깅 별도로 필요함