### PR TITLE
feat: 카카오 계정 로그인 기능 구현 시 CI가 실패하는 문제 해결

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,10 +37,12 @@ jobs:
         env:
           BASE_URL: ${{ secrets.BASE_URL }}
           TOKEN: ${{ secrets.TOKEN }}
+          NATIVE_APP_KEY: ${{ secrets.NATIVE_APP_KEY }}
         run: |
           echo "sdk.dir=/Users/chaehyun/Library/Android/sdk" > ./local.properties
           echo "base_url=$BASE_URL" >> ./local.properties
           echo "token=$TOKEN" >> ./local.properties
+          echo "native_app_key=$NATIVE_APP_KEY" >> ./local.properties
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -84,7 +86,7 @@ jobs:
           echo "sdk.dir=/Users/chaehyun/Library/Android/sdk" > ./local.properties
           echo "base_url=$BASE_URL" >> ./local.properties
           echo "token=$TOKEN" >> ./local.properties
-          echo "native_app_key=$NATIVE_APP_KEY" >> .local.properties
+          echo "native_app_key=$NATIVE_APP_KEY" >> ./local.properties
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     id("de.mannodermaus.android-junit5") version "1.10.0.0"
     id("kotlin-kapt")
     id("com.google.gms.google-services")
-    id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     kotlin("plugin.serialization") version "2.0.0"
     id("com.google.firebase.crashlytics")
 }
@@ -45,7 +44,7 @@ android {
         buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
         buildConfigField("String", "TOKEN", "\"$token\"")
         buildConfigField("String", "NATIVE_APP_KEY", "\"$nativeAppKey\"")
-//        manifestPlaceholders["native_app_key"] = nativeAppKey
+        manifestPlaceholders["native_app_key"] = nativeAppKey
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,7 +49,7 @@
             android:exported="false"
             android:windowSoftInputMode="adjustPan" />
 
-        <!--<activity
+        <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
             <intent-filter>
@@ -59,7 +59,7 @@
                 <data android:host="oauth"
                     android:scheme="kakao${native_app_key}" />
             </intent-filter>
-        </activity>-->
+        </activity>
 
     </application>
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,8 +6,6 @@ buildscript {
     dependencies {
         val navigationVersion = "2.7.7"
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$navigationVersion")
-        val secretsGradlePlugin = "2.0.0"
-        classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:$secretsGradlePlugin")
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #295 
## ✨ 작업 내용
카카오 계정 로그인 기능을 구현하기 위해 매니페스트에서 로컬프로퍼티를 가져오면 ci가 터졌는데 이유를 알아냈어용.. yml파일에서 "/" 하나를 빼먹어서 였습니다.. 엉엉 ㅠㅠ 

## 📚 기타
