### PR TITLE
feat: ParticipantResponse에 참여 인원 현황, 예상 정산 가격 추가

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -11,6 +11,8 @@ import com.zzang.chongdae.offeringmember.domain.OfferingMembers;
 import com.zzang.chongdae.offeringmember.exception.OfferingMemberErrorCode;
 import com.zzang.chongdae.offeringmember.repository.OfferingMemberRepository;
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
+import com.zzang.chongdae.offeringmember.service.dto.ParticipantCountResponseItem;
+import com.zzang.chongdae.offeringmember.service.dto.ParticipantPriceResponseItem;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponse;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponseItem;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
@@ -72,7 +74,12 @@ public class OfferingMemberService {
         List<ParticipantResponseItem> participantsResponseItem = participants.stream()
                 .map(ParticipantResponseItem::new)
                 .toList();
-        return new ParticipantResponse(proposerResponseItem, participantsResponseItem);
+        ParticipantCountResponseItem countResponseItem
+                = new ParticipantCountResponseItem(offering.getCurrentCount(), offering.getTotalCount());
+        ParticipantPriceResponseItem estimatedPriceItem
+                = new ParticipantPriceResponseItem(offering.toOfferingPrice().calculateDividedPrice());
+        return new ParticipantResponse(
+                proposerResponseItem, participantsResponseItem,countResponseItem, estimatedPriceItem);
     }
 
     private void validateParticipants(OfferingEntity offering, MemberEntity member) {

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -12,7 +12,6 @@ import com.zzang.chongdae.offeringmember.exception.OfferingMemberErrorCode;
 import com.zzang.chongdae.offeringmember.repository.OfferingMemberRepository;
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantCountResponseItem;
-import com.zzang.chongdae.offeringmember.service.dto.ParticipantPriceResponseItem;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponse;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponseItem;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
@@ -74,12 +73,10 @@ public class OfferingMemberService {
         List<ParticipantResponseItem> participantsResponseItem = participants.stream()
                 .map(ParticipantResponseItem::new)
                 .toList();
-        ParticipantCountResponseItem countResponseItem
-                = new ParticipantCountResponseItem(offering.getCurrentCount(), offering.getTotalCount());
-        ParticipantPriceResponseItem estimatedPriceItem
-                = new ParticipantPriceResponseItem(offering.toOfferingPrice().calculateDividedPrice());
+        ParticipantCountResponseItem countResponseItem = new ParticipantCountResponseItem(offering);
+        Integer estimatedPrice = offering.toOfferingPrice().calculateDividedPrice();
         return new ParticipantResponse(
-                proposerResponseItem, participantsResponseItem,countResponseItem, estimatedPriceItem);
+                proposerResponseItem, participantsResponseItem,countResponseItem, estimatedPrice);
     }
 
     private void validateParticipants(OfferingEntity offering, MemberEntity member) {

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantCountResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantCountResponseItem.java
@@ -1,0 +1,4 @@
+package com.zzang.chongdae.offeringmember.service.dto;
+
+public record ParticipantCountResponseItem(int currentCount, int totalCount) {
+}

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantCountResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantCountResponseItem.java
@@ -1,4 +1,10 @@
 package com.zzang.chongdae.offeringmember.service.dto;
 
+import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
+
 public record ParticipantCountResponseItem(int currentCount, int totalCount) {
+
+    public ParticipantCountResponseItem(OfferingEntity offering) {
+        this(offering.getCurrentCount(), offering.getCurrentCount());
+    }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantPriceResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantPriceResponseItem.java
@@ -1,0 +1,4 @@
+package com.zzang.chongdae.offeringmember.service.dto;
+
+public record ParticipantPriceResponseItem(int estimated) {
+}

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantPriceResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantPriceResponseItem.java
@@ -1,4 +1,0 @@
-package com.zzang.chongdae.offeringmember.service.dto;
-
-public record ParticipantPriceResponseItem(int estimated) {
-}

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponse.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponse.java
@@ -5,6 +5,6 @@ import java.util.List;
 public record ParticipantResponse(ProposerResponseItem proposer,
                                   List<ParticipantResponseItem> participants,
                                   ParticipantCountResponseItem count,
-                                  ParticipantPriceResponseItem price
+                                  Integer price
 ) {
 }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponse.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponse.java
@@ -2,5 +2,9 @@ package com.zzang.chongdae.offeringmember.service.dto;
 
 import java.util.List;
 
-public record ParticipantResponse(ProposerResponseItem proposer, List<ParticipantResponseItem> participants) {
+public record ParticipantResponse(ProposerResponseItem proposer,
+                                  List<ParticipantResponseItem> participants,
+                                  ParticipantCountResponseItem count,
+                                  ParticipantPriceResponseItem price
+) {
 }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ProposerResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ProposerResponseItem.java
@@ -3,6 +3,7 @@ package com.zzang.chongdae.offeringmember.service.dto;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 
 public record ProposerResponseItem(String nickname) {
+
     public ProposerResponseItem(MemberEntity member) {
         this(member.getNickname());
     }

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
@@ -129,7 +129,10 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
         );
         List<FieldDescriptor> successResponseDescriptors = List.of(
                 fieldWithPath("proposer.nickname").description("공모 작성자 닉네임"),
-                fieldWithPath("participants[].nickname").description("공모 참여자 닉네임")
+                fieldWithPath("participants[].nickname").description("공모 참여자 닉네임"),
+                fieldWithPath("count.currentCount").description("공모 참여자 현재원(작성자 + 참여자)"),
+                fieldWithPath("count.totalCount").description("공모 참여자 총원"),
+                fieldWithPath("price.estimated").description("공모 참여자 예상 정산 가격")
         );
         ResourceSnippetParameters successSnippets = ResourceSnippetParameters.builder()
                 .summary("공모 참여자 목록 조회")

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
@@ -132,7 +132,7 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
                 fieldWithPath("participants[].nickname").description("공모 참여자 닉네임"),
                 fieldWithPath("count.currentCount").description("공모 참여자 현재원(작성자 + 참여자)"),
                 fieldWithPath("count.totalCount").description("공모 참여자 총원"),
-                fieldWithPath("price.estimated").description("공모 참여자 예상 정산 가격")
+                fieldWithPath("price").description("공모 참여자 예상 정산 가격")
         );
         ResourceSnippetParameters successSnippets = ResourceSnippetParameters.builder()
                 .summary("공모 참여자 목록 조회")


### PR DESCRIPTION
## 📌 관련 이슈
close #326 
## ✨ 작업 내용
- ParticipantResponse에 참여 인원 현황, 예상 정산 가격 추가

## 📚 기타
기존 OfferingMemberService의 getAllParticipant에서 내가 참여하고 있는 공모인지 검증하기 위해, Offering 엔티티를 찾아오는 과정이 있습니다. 여기서 Offering에 대한 정보가 메서드 내에 존재하기에, 하기 댓글방 슬라이딩 뷰와 같이 보여지도록 현재원, 총원, 예상 정산 가격을 Offering을 활용하여 추가하였습니다. 큰 변경 없이 Response에 슬라이딩 뷰에 대한 정보를 한 API로 전달할 수 있었습니다.

여기서 고민이 발생했습니다. 현재 이 공모에 대한 참여자가 누군지에 대한 정보를 받는 것을 요청하는 API에서, OfferingMember가 아닌 Offering의 내용이 직접적으로 들어가도 되는가? 그렇다면 다른 API로 분리해야 하는 것이 아닌가? 라는 것입니다.

아직 현 코드에 대한 리팩토링은 진행하지 않았습니다. 위와 같은 점에 대해서 논의를 더 해봐야 도메인 로직으로 분리하기 적절하다고 판단했습니다. 특히 Proposer, Participants로 분리해볼만한 여지가 여실하네요.

가감없는 피드백 부탁합니다.

![image](https://github.com/user-attachments/assets/6d1fcbf7-179a-4c51-b646-5c5a4be3cad3)
