### PR TITLE
feat: 로그인 시에도 memberId와 nickName을 받아서 data store에 저장하는 기능 구현

### DIFF
--- a/android/app/src/main/java/com/zzang/chongdae/data/remote/api/AuthApiService.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/remote/api/AuthApiService.kt
@@ -10,7 +10,7 @@ interface AuthApiService {
     @POST("/auth/login")
     suspend fun postLogin(
         @Body ci: CiRequest,
-    ): Response<Unit>
+    ): Response<MemberResponse>
 
     @POST("/auth/refresh")
     suspend fun postRefresh(): Response<Unit>

--- a/android/app/src/main/java/com/zzang/chongdae/data/remote/source/AuthRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/remote/source/AuthRemoteDataSourceImpl.kt
@@ -8,7 +8,7 @@ import com.zzang.chongdae.data.source.AuthRemoteDataSource
 class AuthRemoteDataSourceImpl(
     private val service: AuthApiService,
 ) : AuthRemoteDataSource {
-    override suspend fun saveLogin(ciRequest: CiRequest): Result<Unit> {
+    override suspend fun saveLogin(ciRequest: CiRequest): Result<MemberResponse> {
         return runCatching {
             val response = service.postLogin(ciRequest)
             if (response.isSuccessful) {

--- a/android/app/src/main/java/com/zzang/chongdae/data/repository/AuthRepositoryImpl.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/repository/AuthRepositoryImpl.kt
@@ -9,10 +9,10 @@ import com.zzang.chongdae.domain.repository.AuthRepository
 class AuthRepositoryImpl(
     private val authRemoteDataSource: AuthRemoteDataSource,
 ) : AuthRepository {
-    override suspend fun saveLogin(ci: String): Result<Unit> {
+    override suspend fun saveLogin(ci: String): Result<Member> {
         return authRemoteDataSource.saveLogin(
             ciRequest = CiRequest(ci),
-        )
+        ).mapCatching { it.toDomain() }
     }
 
     override suspend fun saveRefresh(): Result<Unit> {

--- a/android/app/src/main/java/com/zzang/chongdae/data/source/AuthRemoteDataSource.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/source/AuthRemoteDataSource.kt
@@ -4,7 +4,7 @@ import com.zzang.chongdae.data.remote.dto.request.CiRequest
 import com.zzang.chongdae.data.remote.dto.response.MemberResponse
 
 interface AuthRemoteDataSource {
-    suspend fun saveLogin(ciRequest: CiRequest): Result<Unit>
+    suspend fun saveLogin(ciRequest: CiRequest): Result<MemberResponse>
 
     suspend fun saveRefresh(): Result<Unit>
 

--- a/android/app/src/main/java/com/zzang/chongdae/domain/repository/AuthRepository.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/domain/repository/AuthRepository.kt
@@ -3,7 +3,7 @@ package com.zzang.chongdae.domain.repository
 import com.zzang.chongdae.domain.model.Member
 
 interface AuthRepository {
-    suspend fun saveLogin(ci: String): Result<Unit>
+    suspend fun saveLogin(ci: String): Result<Member>
 
     suspend fun saveRefresh(): Result<Unit>
 

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/login/LoginViewModel.kt
@@ -24,6 +24,7 @@ class LoginViewModel(
             authRepository.saveLogin(
                 ci = ci,
             ).onSuccess {
+                memberDataStore.saveMember(it.memberId, it.nickName)
                 _navigateEvent.setValue(true)
             }.onFailure {
                 Log.e("error", "postLogin: ${it.message}")

--- a/android/app/src/test/java/com/zzang/chongdae/repository/FakeAuthRepository.kt
+++ b/android/app/src/test/java/com/zzang/chongdae/repository/FakeAuthRepository.kt
@@ -4,7 +4,7 @@ import com.zzang.chongdae.domain.model.Member
 import com.zzang.chongdae.domain.repository.AuthRepository
 
 class FakeAuthRepository : AuthRepository {
-    override suspend fun saveLogin(ci: String): Result<Unit> {
+    override suspend fun saveLogin(ci: String): Result<Member> {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #345 
## ✨ 작업 내용
- 로그인 시에도 회원가입 시와 마찬가지로 서버에서 memberId와 nickName을 내려받습니다. 그리고 데이터스토어에 저장해줍니다.
## 📚 기타
별거 없서용~