### PR TITLE
fix: 댓글방 목록의 마지막 댓글방이 보이지 않는 문제 수정

### DIFF
--- a/android/app/src/main/res/layout/fragment_comment_rooms.xml
+++ b/android/app/src/main/res/layout/fragment_comment_rooms.xml
@@ -63,5 +63,13 @@
             app:layout_constraintBottom_toBottomOf="parent"
             tools:listitem="@layout/item_comment_room_participant" />
 
+        <View
+            android:id="@+id/view_divide_line2"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/gray_300"
+            app:layout_constraintTop_toBottomOf="@id/rv_comment_room"
+            app:layout_constraintStart_toStartOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_comment_rooms.xml
+++ b/android/app/src/main/res/layout/fragment_comment_rooms.xml
@@ -19,6 +19,18 @@
         android:layout_height="match_parent"
         tools:context=".presentation.view.comment.CommentRoomsFragment">
 
+        <ImageView
+            android:id="@+id/iv_empty_comment_room"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:foregroundGravity="center_vertical"
+            android:src="@drawable/img_comment_room_empty_comment_room"
+            app:isVisible="@{vm.isCommentRoomsEmpty}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <TextView
             android:id="@+id/tv_comment_text"
             android:layout_width="wrap_content"
@@ -32,34 +44,23 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/iv_empty_comment_room"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:foregroundGravity="center_vertical"
-            android:src="@drawable/img_comment_room_empty_comment_room"
-            app:isVisible="@{vm.isCommentRoomsEmpty}"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
         <View
             android:id="@+id/view_divide_line"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="@color/gray_300"
-            app:layout_constraintBottom_toTopOf="@id/rv_comment_room"
+            android:layout_marginTop="15dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_comment_text"
             app:layout_constraintStart_toStartOf="parent" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_comment_room"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
+            android:layout_height="0dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_comment_text"
+            app:layout_constraintTop_toBottomOf="@id/view_divide_line"
+            app:layout_constraintBottom_toBottomOf="parent"
             tools:listitem="@layout/item_comment_room_participant" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/fragment_comment_rooms.xml
+++ b/android/app/src/main/res/layout/fragment_comment_rooms.xml
@@ -48,19 +48,19 @@
             android:id="@+id/view_divide_line"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="@color/gray_300"
             android:layout_marginTop="15dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_comment_text"
-            app:layout_constraintStart_toStartOf="parent" />
+            android:background="@color/gray_300"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_comment_text" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_comment_room"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_divide_line"
-            app:layout_constraintBottom_toBottomOf="parent"
             tools:listitem="@layout/item_comment_room_participant" />
 
         <View
@@ -68,8 +68,8 @@
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="@color/gray_300"
-            app:layout_constraintTop_toBottomOf="@id/rv_comment_room"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/rv_comment_room" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 📌 관련 이슈
close #374 
## ✨ 작업 내용
댓글방 목록의 마지막 댓글방이 안보이는 문제 해결했습니다

![image](https://github.com/user-attachments/assets/a526ebe2-7ea6-4955-a758-6389a7d7d3c0)
수정전

![image](https://github.com/user-attachments/assets/9eab80ef-47a1-4cae-875a-74347f22efa9)
수정후

그리고 기존에는 각각의 아이템에만 하단에 구분선이 붙어있었기 때문에 리사이클러뷰를 아래로 땡기면 이 구분선이 사라져버렸는데 리사이클러뷰의 layout 최하단에도 구분선을 하나 붙여서 사라지지 않게 했습니다.

## 📚 기타
별거없음