### PR TITLE
feat: 공모글 목록에서 주소의 동을 보여주는 기능 구현

### DIFF
--- a/android/app/src/main/java/com/zzang/chongdae/data/mapper/OfferingMapper.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/mapper/OfferingMapper.kt
@@ -7,7 +7,7 @@ fun RemoteOffering.toDomain() =
     Offering(
         id = this.id,
         title = this.title,
-        meetingAddress = this.meetingAddress ?: "",
+        meetingAddressDong = this.meetingAddressDong ?: "",
         thumbnailUrl = this.thumbnailUrl,
         totalCount = this.totalCount,
         currentCount = this.currentCount,

--- a/android/app/src/main/java/com/zzang/chongdae/data/remote/dto/response/offering/RemoteOffering.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/remote/dto/response/offering/RemoteOffering.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 data class RemoteOffering(
     @SerialName("id") val id: Long,
     @SerialName("title") val title: String,
-    @SerialName("meetingAddressDong") val meetingAddress: String?,
+    @SerialName("meetingAddressDong") val meetingAddressDong: String?,
     @SerialName("currentCount") val currentCount: Int,
     @SerialName("totalCount") val totalCount: Int,
     @SerialName("thumbnailUrl") val thumbnailUrl: String?,

--- a/android/app/src/main/java/com/zzang/chongdae/domain/model/Offering.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/domain/model/Offering.kt
@@ -3,7 +3,7 @@ package com.zzang.chongdae.domain.model
 data class Offering(
     val id: Long,
     val title: String,
-    val meetingAddress: String,
+    val meetingAddressDong: String,
     val thumbnailUrl: String?,
     val totalCount: Int,
     val currentCount: Int,

--- a/android/app/src/main/java/com/zzang/chongdae/domain/model/OfferingDetail.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/domain/model/OfferingDetail.kt
@@ -25,7 +25,7 @@ fun OfferingDetail.toOffering(): Offering {
     return Offering(
         id = this.id,
         title = this.title,
-        meetingAddress = this.meetingAddress,
+        meetingAddressDong = this.meetingAddress,
         thumbnailUrl = this.thumbnailUrl,
         totalCount = this.totalCount,
         currentCount = this.currentCount.value,

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/write/OfferingWriteViewModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/write/OfferingWriteViewModel.kt
@@ -40,8 +40,6 @@ class OfferingWriteViewModel(
 
     val meetingAddress: MutableLiveData<String> = MutableLiveData("")
 
-    private val meetingAddressDong: MutableLiveData<String?> = MutableLiveData()
-
     val meetingAddressDetail: MutableLiveData<String> = MutableLiveData("")
 
     val meetingDate: MutableLiveData<String> = MutableLiveData("")
@@ -232,6 +230,7 @@ class OfferingWriteViewModel(
 
         val totalCountConverted = makeTotalCountInvalidEvent(totalCount) ?: return
         val totalPriceConverted = makeTotalPriceInvalidEvent(totalPrice) ?: return
+        val meetingAddressDong = extractDong(meetingAddress)
 
         var originPriceNotBlank: Int? = 0
         runCatching {
@@ -253,7 +252,7 @@ class OfferingWriteViewModel(
                         totalPrice = totalPriceConverted,
                         originPrice = originPriceNotBlank,
                         meetingAddress = meetingAddress,
-                        meetingAddressDong = meetingAddressDong.value,
+                        meetingAddressDong = meetingAddressDong,
                         meetingAddressDetail = meetingAddressDetail,
                         meetingDate = meetingDate,
                         description = description,
@@ -277,6 +276,13 @@ class OfferingWriteViewModel(
             throw NumberFormatException()
         }
         return originPriceInputTrim.toInt()
+    }
+
+    private fun extractDong(address: String): String? {
+        val regex = """\((.*?)\)""".toRegex()
+        val matchResult = regex.find(address)
+        val content = matchResult?.groups?.get(1)?.value
+        return content?.split(",")?.get(0)?.trim()
     }
 
     private fun makeTotalCountInvalidEvent(totalCount: String): Int? {

--- a/android/app/src/main/res/layout/item_offering.xml
+++ b/android/app/src/main/res/layout/item_offering.xml
@@ -84,9 +84,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:text="내발산동"
+            android:text="@{offering.meetingAddressDong}"
             app:layout_constraintStart_toStartOf="@id/tv_offering_title"
-            app:layout_constraintTop_toBottomOf="@id/tv_offering_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_offering_title"
+            tools:text="내발산동" />
 
         <TextView
             android:id="@+id/tv_offering_condition_comment"

--- a/android/app/src/test/java/com/zzang/chongdae/repository/FakeOfferingRepository.kt
+++ b/android/app/src/test/java/com/zzang/chongdae/repository/FakeOfferingRepository.kt
@@ -22,7 +22,7 @@ class FakeOfferingRepository : OfferingRepository {
                 Offering(
                     id = 0,
                     title = "",
-                    meetingAddress = "",
+                    meetingAddressDong = "",
                     thumbnailUrl = null,
                     totalCount = 0,
                     currentCount = 0,

--- a/android/app/src/test/java/com/zzang/chongdae/util/TestFixture.kt
+++ b/android/app/src/test/java/com/zzang/chongdae/util/TestFixture.kt
@@ -71,7 +71,7 @@ object TestFixture {
             Offering(
                 id = it.toLong(),
                 title = "",
-                meetingAddress = "",
+                meetingAddressDong = "",
                 thumbnailUrl = null,
                 totalCount = 0,
                 currentCount = 0,


### PR DESCRIPTION
## 📌 관련 이슈
close #378 
## ✨ 작업 내용
주소에서 동을 파싱해서 서버로 보내줍니다. 이제 공모 목록에서 동을 보여줍니다.
![image](https://github.com/user-attachments/assets/fff27e7f-6951-4fba-8dda-2db9981c37b7)

만약 동이 없는 주소일 경우 blank로 아무것도 안 띄웁니다.
## 📚 기타
