### PR TITLE
chore: JAR 파일에 OAS 파일 누락되는 이슈 해결 및 중복 task 제거

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ "develop-BE" ]
     paths: [ "backend/**" ]
-    # pull_request:
-    # branches: [ "develop-BE" ]
+  pull_request:
+    branches: [ "develop-BE" ]
 
 jobs:
 
@@ -38,10 +38,7 @@ jobs:
 #        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5
 
       - name: Build with Gradle Wrapper
-        run: |
-          ./gradlew clean
-          ./gradlew copyOasToSwagger
-          ./gradlew build
+        run: ./gradlew clean build
         working-directory: ./backend
 
       - name: Docker build and push

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ "develop-BE" ]
     paths: [ "backend/**" ]
-  pull_request:
-    branches: [ "develop-BE" ]
+  # pull_request:
+  #   branches: [ "develop-BE" ]
 
 jobs:
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -71,6 +71,10 @@ tasks.register('copyOasToSwagger', Copy) {
 
 bootJar {
     dependsOn copyOasToSwagger
+    from('src/main/resources/static/swagger-ui') {
+        include 'openapi3.yaml'
+        into 'static/swagger-ui/'
+    }
 }
 
 jar {


### PR DESCRIPTION
## 📌 관련 이슈
close #143 
## ✨ 작업 내용
- JAR 파일에 OAS 파일 누락되는 이슈 해결 및 중복 task 제거
## 📚 기타
- 해당 코드 적용 후, 로컬 환경에서 OAS 파일을 삭제한 후 빌드했을 때, JAR 파일에 OAS 파일이 정상적으로 포함되는 것을 확인했습니다.
  - [문제] 해당 코드 적용 전에는 OAS 파일을 삭제한 후 빌드했을 때, JAR 파일에 OAS 파일이 포함되지 않았습니다.
    - static 경로의 파일들은 모두 processResources 태스크에서 처리되는데, 이 태스크는 OAS 파일을 생성하는 태스크보다 앞서 실행됩니다.
    - 따라서 이후 실행되는 bootJar 태스크는 processResources 태스크에서 처리한 static 경로의 파일만 인식하기 때문에, OAS 파일을 인식하지 못했습니다.
  - [해결] 이 문제를 해결하기 위해 bootJar 태스크에서 OAS 파일을 명시적으로 포함시켰습니다. 이렇게 하면 bootJar 태스크가 OAS 파일을 인식하여 JAR 파일에 포함할 수 있게 됩니다.
- 해당 코드 적용 후, 배포 환경에서도 동일하게 oas 파일 누락되지 않는 거 확인했습니다.
<img width="1900" alt="스크린샷 2024-08-20 오전 12 39 03" src="https://github.com/user-attachments/assets/72612082-a559-48b3-a892-c95696c64b98">