### PR TITLE
fix: 참여자 목록 조회 API에서 totalCount 반환하지 않는 이슈 해결

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantCountResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantCountResponseItem.java
@@ -5,6 +5,6 @@ import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 public record ParticipantCountResponseItem(int currentCount, int totalCount) {
 
     public ParticipantCountResponseItem(OfferingEntity offering) {
-        this(offering.getCurrentCount(), offering.getCurrentCount());
+        this(offering.getCurrentCount(), offering.getTotalCount());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #399 
## ✨ 작업 내용
- 참여자 목록 조회 API에서 totalCount 반환하지 않는 이슈 해결
## 📚 기타
