### PR TITLE
fix: 공구 상세 페이지 오류 해결

### DIFF
--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailFragment.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailFragment.kt
@@ -68,6 +68,10 @@ class OfferingDetailFragment : Fragment() {
         viewModel.reportEvent.observe(viewLifecycleOwner) { reportUrlId ->
             openUrlInBrowser(getString(reportUrlId))
         }
+
+        viewModel.productLinkRedirectEvent.observe(viewLifecycleOwner) { productURL ->
+            openUrlInBrowser(productURL)
+        }
     }
 
     private fun openUrlInBrowser(url: String) {

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailViewModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailViewModel.kt
@@ -25,7 +25,8 @@ class OfferingDetailViewModel(
 ) : ViewModel(),
     OnParticipationClickListener,
     OnOfferingReportClickListener,
-    OnMoveCommentDetailClickListener {
+    OnMoveCommentDetailClickListener,
+    OnProductLinkClickListener {
     private val _offeringDetail: MutableLiveData<OfferingDetail> = MutableLiveData()
     val offeringDetail: LiveData<OfferingDetail> get() = _offeringDetail
 
@@ -53,6 +54,9 @@ class OfferingDetailViewModel(
     private val _reportEvent: MutableSingleLiveData<Int> = MutableSingleLiveData()
     val reportEvent: SingleLiveData<Int> get() = _reportEvent
 
+    private val _productLinkRedirectEvent: MutableSingleLiveData<String> = MutableSingleLiveData()
+    val productLinkRedirectEvent: SingleLiveData<String> get() = _productLinkRedirectEvent
+
     init {
         loadOffering()
     }
@@ -66,6 +70,7 @@ class OfferingDetailViewModel(
                             authRepository.saveRefresh()
                             loadOffering()
                         }
+
                         else -> DataError.Network.UNKNOWN
                     }
 
@@ -91,6 +96,7 @@ class OfferingDetailViewModel(
                             authRepository.saveRefresh()
                             onClickParticipation()
                         }
+
                         else -> DataError.Network.UNKNOWN
                     }
 
@@ -109,6 +115,10 @@ class OfferingDetailViewModel(
 
     override fun onClickReport() {
         _reportEvent.setValue(R.string.report_url)
+    }
+
+    override fun onClickProductRedirectText(productUrl: String) {
+        _productLinkRedirectEvent.setValue(productUrl)
     }
 
     private fun isParticipationEnabled(

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OnProductLinkClickListener.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OnProductLinkClickListener.kt
@@ -1,0 +1,5 @@
+package com.zzang.chongdae.presentation.view.offeringdetail
+
+interface OnProductLinkClickListener {
+    fun onClickProductRedirectText(productUrl: String)
+}

--- a/android/app/src/main/res/layout/fragment_offering_detail.xml
+++ b/android/app/src/main/res/layout/fragment_offering_detail.xml
@@ -163,14 +163,14 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:fontFamily="@font/suit_bold"
+                        android:onClick="@{() -> vm.onClickProductRedirectText(vm.offeringDetail.productUrl)}"
                         android:text="@string/detail_product_url_text"
                         android:textColor="@color/main_color"
                         android:textSize="16sp"
                         app:isVisible="@{vm.offeringDetail.productUrl != null}"
                         app:layout_constraintBottom_toBottomOf="@id/tv_product_link_comment"
                         app:layout_constraintStart_toEndOf="@id/tv_product_link_comment"
-                        app:layout_constraintTop_toTopOf="@id/tv_product_link_comment"
-                        app:url="@{vm.offeringDetail.productUrl}" />
+                        app:layout_constraintTop_toTopOf="@id/tv_product_link_comment" />
 
                     <View
                         android:id="@+id/horizon_line"
@@ -280,15 +280,25 @@
                     <TextView
                         android:id="@+id/tv_meeting_address"
                         style="@style/Theme.AppCompat.TextView.Normal.Gray500.Size14"
+                        android:layout_width="0dp"
                         android:layout_marginTop="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="2"
+                        android:paddingEnd="@dimen/size_5"
                         android:text="@{vm.offeringDetail.meetingAddress}"
+                        app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="@id/iv_location"
                         app:layout_constraintTop_toBottomOf="@id/iv_location"
-                        tools:text="서울시 동작구 보라매로 70" />
+                        tools:text="부산광역시 강서구 녹산산단382로14번가길 10~29번지(송정동)" />
 
                     <TextView
                         android:id="@+id/tv_meeting_address_detail"
                         style="@style/Theme.AppCompat.TextView.Normal.Gray500.Size14"
+                        android:layout_width="0dp"
+                        android:layout_marginTop="@dimen/size_4"
+                        android:ellipsize="end"
+                        android:maxLines="2"
+                        android:paddingEnd="@dimen/size_5"
                         android:text="@{vm.offeringDetail.meetingAddressDetail}"
                         app:layout_constraintStart_toStartOf="@id/tv_meeting_address"
                         app:layout_constraintTop_toBottomOf="@id/tv_meeting_address"


### PR DESCRIPTION
## 📌 관련 이슈
close #395 
## ✨ 작업 내용

- 바로가기 안눌림 오류
  - 바로가기에 하이퍼링크를 직접 거는 방식 대신 클릭 이벤트를 설정하는 방식으로 리팩토링하여 해결하였습니다.
  
- 공구 상세페이지에서 주소가 길 경우 말줄임표 또는 줄바꿈을 통해 보여주도록 수정
  - 주소, 상세주소 모두 최대 2줄까지 보여주고 넘어갈 시 끝에 말 줄임...으로 표시하도록 리팩토링 하였습니다.


## 📚 기타
없습니다!