### PR TITLE
feat: 리프레시 토큰 만료 시 데이터스토어를 비우고 로그인 화면으로 이동하는 기능 구현

### DIFF
--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/home/HomeFragment.kt
@@ -23,12 +23,15 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.zzang.chongdae.ChongdaeApp
+import com.zzang.chongdae.ChongdaeApp.Companion.dataStore
 import com.zzang.chongdae.R
+import com.zzang.chongdae.data.local.source.UserPreferencesDataStore
 import com.zzang.chongdae.databinding.FragmentHomeBinding
 import com.zzang.chongdae.domain.model.FilterName
 import com.zzang.chongdae.presentation.util.FirebaseAnalyticsManager
 import com.zzang.chongdae.presentation.view.MainActivity
 import com.zzang.chongdae.presentation.view.home.adapter.OfferingAdapter
+import com.zzang.chongdae.presentation.view.login.LoginActivity
 import com.zzang.chongdae.presentation.view.offeringdetail.OfferingDetailFragment
 import com.zzang.chongdae.presentation.view.write.OfferingWriteOptionalFragment
 import kotlinx.coroutines.launch
@@ -43,6 +46,7 @@ class HomeFragment : Fragment(), OnOfferingClickListener {
         OfferingViewModel.getFactory(
             offeringRepository = (requireActivity().application as ChongdaeApp).offeringRepository,
             authRepository = (requireActivity().applicationContext as ChongdaeApp).authRepository,
+            userPreferencesDataStore = UserPreferencesDataStore(requireActivity().applicationContext.dataStore),
         )
     }
 
@@ -203,6 +207,10 @@ class HomeFragment : Fragment(), OnOfferingClickListener {
             offeringAdapter.addUpdatedItem(it.toList())
         }
         viewModel.updatedOffering.getValue()?.toList()?.let { offeringAdapter.addUpdatedItem(it) }
+
+        viewModel.refreshTokenExpiredEvent.observe(viewLifecycleOwner) {
+            LoginActivity.startActivity(requireContext())
+        }
     }
 
     override fun onClick(offeringId: Long) {

--- a/android/app/src/test/java/com/zzang/chongdae/presentation/view/home/OfferingViewModelTest.kt
+++ b/android/app/src/test/java/com/zzang/chongdae/presentation/view/home/OfferingViewModelTest.kt
@@ -1,8 +1,10 @@
 package com.zzang.chongdae.presentation.view.home
 
+import com.zzang.chongdae.data.local.source.UserPreferencesDataStore
 import com.zzang.chongdae.domain.repository.AuthRepository
 import com.zzang.chongdae.domain.repository.OfferingRepository
 import com.zzang.chongdae.repository.FakeAuthRepository
+import com.zzang.chongdae.repository.FakeDataStore
 import com.zzang.chongdae.repository.FakeOfferingRepository
 import com.zzang.chongdae.util.CoroutinesTestExtension
 import com.zzang.chongdae.util.InstantTaskExecutorExtension
@@ -21,12 +23,14 @@ class OfferingViewModelTest {
     private lateinit var viewModel: OfferingViewModel
     private lateinit var offeringRepository: OfferingRepository
     private lateinit var authRepository: AuthRepository
+    private lateinit var userPreferencesDataStore: UserPreferencesDataStore
 
     @BeforeEach
     fun setUp() {
         offeringRepository = FakeOfferingRepository()
         authRepository = FakeAuthRepository()
-        viewModel = OfferingViewModel(offeringRepository, authRepository)
+        userPreferencesDataStore = UserPreferencesDataStore(FakeDataStore())
+        viewModel = OfferingViewModel(offeringRepository, authRepository, userPreferencesDataStore)
     }
 
     @DisplayName("필터 정보를 불러온다")


### PR DESCRIPTION
## 📌 관련 이슈
close #437 
## ✨ 작업 내용
리프레시 토큰 만료 시 데이터스토어를 비우고 로그인 화면으로 이동하는 기능 구현
## 📚 기타
