### PR TITLE
fix: og 크롤링 정상 작동 시 http https 프로토콜 정보 제거

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/service/OgTagProductImageExtractor.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/service/OgTagProductImageExtractor.java
@@ -13,6 +13,17 @@ public class OgTagProductImageExtractor implements ProductImageExtractor {
     @Override
     public String extract(String productUrl) {
         String html = htmlCrawler.scrap(productUrl);
-        return htmlCrawler.parseOpenGraph(html, OG_IMAGE_PROPERTY);
+        return removeHttpHttps(htmlCrawler.parseOpenGraph(html, OG_IMAGE_PROPERTY));
     }
+
+    public String removeHttpHttps(String url) {
+        if (url.startsWith("http:")) {
+            return url.substring("http:".length());
+        }
+        if (url.startsWith("https:")) {
+            return url.substring("https:".length());
+        }
+        return url;
+    }
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #450 
## ✨ 작업 내용
- og 크롤링 정상 작동 시 http https 프로토콜 정보 제거
## 📚 기타
