### PR TITLE
feat: 공모 삭제 API 구현

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingController.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingController.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.Min;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -104,5 +105,13 @@ public class OfferingController {
             @RequestBody @Valid OfferingProductImageRequest request) {
         OfferingProductImageResponse response = offeringService.extractProductImageFromOg(request);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/offerings/{offering-id}")
+    public ResponseEntity<Void> deleteOffering(
+            @PathVariable(value = "offering-id") Long offeringId,
+            MemberEntity member) { // TODO: 머지 후 위치 조정
+        offeringService.deleteOffering(offeringId, member);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/domain/CommentRoomStatus.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/domain/CommentRoomStatus.java
@@ -31,7 +31,11 @@ public enum CommentRoomStatus {
         return this == BUYING;
     }
 
-    public boolean isInProgress() {
+    public boolean isStarted() {
         return this != GROUPING;
+    }
+
+    public boolean isInProgress() {
+        return this == BUYING || this == TRADING;
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/domain/CommentRoomStatus.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/domain/CommentRoomStatus.java
@@ -31,7 +31,7 @@ public enum CommentRoomStatus {
         return this == BUYING;
     }
 
-    public boolean isStarted() {
+    public boolean isGrouped() {
         return this != GROUPING;
     }
 

--- a/backend/src/main/java/com/zzang/chongdae/offering/exception/OfferingErrorCode.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/exception/OfferingErrorCode.java
@@ -20,7 +20,9 @@ public enum OfferingErrorCode implements ErrorResponse {
     INVALID_CONDITION(BAD_REQUEST, "유효하지 않은 공모 상태입니다"),
     NOT_PARTICIPATE_MEMBER(BAD_REQUEST, "해당 공모의 참여자가 아닙니다."),
     NOT_PROPOSE_MEMBER(BAD_REQUEST, "해당 공모의 총대가 아닙니다."),
-    CANNOT_ORIGIN_PRICE_LESS_THEN_DIVIDED_PRICE(BAD_REQUEST, "원가 가격이 n빵 가격보다 작을 수 없습니다.");
+    CANNOT_ORIGIN_PRICE_LESS_THEN_DIVIDED_PRICE(BAD_REQUEST, "원가 가격이 n빵 가격보다 작을 수 없습니다."),
+    CANNOT_DELETE_STATUS(BAD_REQUEST, "삭제할 수 없는 거래 상태입니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/zzang/chongdae/offering/service/OfferingService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/service/OfferingService.java
@@ -129,4 +129,11 @@ public class OfferingService {
         String imageUrl = imageExtractor.extract(request.productUrl());
         return new OfferingProductImageResponse(imageUrl);
     }
+
+    public void deleteOffering(Long offeringId, MemberEntity member) {
+        OfferingEntity offering = offeringRepository.findById(offeringId)
+                .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
+        validateIsProposer(offering, member);
+        offeringRepository.delete(offering);
+    }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/service/OfferingService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/service/OfferingService.java
@@ -134,6 +134,13 @@ public class OfferingService {
         OfferingEntity offering = offeringRepository.findById(offeringId)
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateIsProposer(offering, member);
+        validateInProgress(offering);
         offeringRepository.delete(offering);
+    }
+
+    private void validateInProgress(OfferingEntity offering) {
+        if (offering.getRoomStatus().isInProgress()) {
+            throw new MarketException(OfferingErrorCode.CANNOT_DELETE_STATUS);
+        }
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -89,7 +89,7 @@ public class OfferingMemberService {
     private void validateInProgress(OfferingMemberEntity offeringMember) {
         OfferingEntity offering = offeringMember.getOffering();
         CommentRoomStatus roomStatus = offering.getRoomStatus();
-        if (roomStatus.isInProgress()) {
+        if (roomStatus.isStarted()) {
             throw new MarketException(OfferingMemberErrorCode.CANNOT_CANCEL_IN_PROGRESS);
         }
     }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -89,7 +89,7 @@ public class OfferingMemberService {
     private void validateInProgress(OfferingMemberEntity offeringMember) {
         OfferingEntity offering = offeringMember.getOffering();
         CommentRoomStatus roomStatus = offering.getRoomStatus();
-        if (roomStatus.isStarted()) {
+        if (roomStatus.isGrouped()) {
             throw new MarketException(OfferingMemberErrorCode.CANNOT_CANCEL_IN_PROGRESS);
         }
     }

--- a/backend/src/test/java/com/zzang/chongdae/global/domain/OfferingFixture.java
+++ b/backend/src/test/java/com/zzang/chongdae/global/domain/OfferingFixture.java
@@ -40,4 +40,8 @@ public class OfferingFixture {
     public OfferingEntity createOffering(MemberEntity member) {
         return createOffering(member, CommentRoomStatus.GROUPING);
     }
+
+    public long countOffering() {
+        return offeringRepository.count();
+    }
 }

--- a/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
@@ -788,6 +788,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
         MemberEntity notProposer;
         OfferingEntity offering;
         OfferingEntity offeringInProgress;
+        OfferingEntity offeringDone;
 
         @BeforeEach
         void setUp() {
@@ -795,6 +796,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
             proposer = memberFixture.createMember("ever");
             offering = offeringFixture.createOffering(proposer);
             offeringInProgress = offeringFixture.createOffering(proposer, CommentRoomStatus.TRADING);
+            offeringDone = offeringFixture.createOffering(proposer, CommentRoomStatus.DONE);
         }
 
         @DisplayName("공모 id로 공모를 삭제할 수 있다")
@@ -843,6 +845,17 @@ public class OfferingIntegrationTest extends IntegrationTest {
                     .when().delete("/offerings/{offering-id}")
                     .then().log().all()
                     .statusCode(400);
+        }
+
+        @DisplayName("거래가 완료된 공모를 삭제할 수 있다.")
+        @Test
+        void should_deleteOffering_when_givenDoneOffering() {
+            given().log().all()
+                    .cookies(cookieProvider.createCookiesWithMember(proposer))
+                    .pathParam("offering-id", offeringDone.getId())
+                    .when().delete("/offerings/{offering-id}")
+                    .then().log().all()
+                    .statusCode(204);
         }
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
@@ -786,6 +786,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
 
         MemberEntity proposer;
         MemberEntity notProposer;
+        MemberEntity participant;
         OfferingEntity offering;
         OfferingEntity offeringInProgress;
         OfferingEntity offeringDone;
@@ -795,6 +796,8 @@ public class OfferingIntegrationTest extends IntegrationTest {
             notProposer = memberFixture.createMember("never");
             proposer = memberFixture.createMember("ever");
             offering = offeringFixture.createOffering(proposer);
+            participant = memberFixture.createMember("naver");
+            offeringMemberFixture.createParticipant(participant, offering);
             offeringInProgress = offeringFixture.createOffering(proposer, CommentRoomStatus.TRADING);
             offeringDone = offeringFixture.createOffering(proposer, CommentRoomStatus.DONE);
         }
@@ -829,6 +832,18 @@ public class OfferingIntegrationTest extends IntegrationTest {
             given(spec).log().all()
                     .filter(document("delete-offering-fail-not-proposer", resource(failSnippets)))
                     .cookies(cookieProvider.createCookiesWithMember(notProposer))
+                    .pathParam("offering-id", offering.getId())
+                    .when().delete("/offerings/{offering-id}")
+                    .then().log().all()
+                    .statusCode(400);
+        }
+
+        @DisplayName("참여자가 공모 삭제를 시도할 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_participant() {
+            given(spec).log().all()
+                    .filter(document("delete-offering-fail-participant", resource(failSnippets)))
+                    .cookies(cookieProvider.createCookiesWithMember(participant))
                     .pathParam("offering-id", offering.getId())
                     .when().delete("/offerings/{offering-id}")
                     .then().log().all()

--- a/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
@@ -141,4 +141,18 @@ public class OfferingServiceTest extends ServiceTest {
         assertThatThrownBy(() -> offeringService.deleteOffering(offering.getId(), proposer))
                 .isInstanceOf(MarketException.class);
     }
+
+    @DisplayName("거래 완료 상태 공모의 경우 삭제가 가능하다.")
+    @Test
+    void should_deleteAvailable_when_statusDone() {
+        // given
+        MemberEntity proposer = memberFixture.createMember("ever");
+        OfferingEntity offering = offeringFixture.createOffering(proposer, CommentRoomStatus.DONE);
+
+        // when
+        offeringService.deleteOffering(offering.getId(), proposer);
+
+        // then
+        assertThat(offeringFixture.countOffering()).isEqualTo(0);
+    }
 }

--- a/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.zzang.chongdae.global.exception.MarketException;
 import com.zzang.chongdae.global.service.ServiceTest;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.offering.domain.CommentRoomStatus;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import com.zzang.chongdae.offering.service.dto.OfferingAllResponseItem;
 import com.zzang.chongdae.offering.service.dto.OfferingSaveRequest;
@@ -114,6 +115,30 @@ public class OfferingServiceTest extends ServiceTest {
         long invalidOfferingId = offering.getId() + 9999;
 
         assertThatThrownBy(() -> offeringService.deleteOffering(invalidOfferingId, proposer))
+                .isInstanceOf(MarketException.class);
+    }
+
+    @DisplayName("거래 인원이 확정되고 거래가 완료되기 전 (구매 중 상태) 삭제를 시도할 경우 예외가 발생한다.")
+    @Test
+    void should_throwException_when_deleteAtBuyingStatus() {
+        // given
+        MemberEntity proposer = memberFixture.createMember("ever");
+        OfferingEntity offering = offeringFixture.createOffering(proposer, CommentRoomStatus.BUYING);
+
+        // when & then
+        assertThatThrownBy(() -> offeringService.deleteOffering(offering.getId(), proposer))
+                .isInstanceOf(MarketException.class);
+    }
+
+    @DisplayName("거래 인원이 확정되고 거래가 완료되기 전 (거래 중 상태) 삭제를 시도할 경우 예외가 발생한다.")
+    @Test
+    void should_throwException_when_deleteAtTradingStatus() {
+        // given
+        MemberEntity proposer = memberFixture.createMember("ever");
+        OfferingEntity offering = offeringFixture.createOffering(proposer, CommentRoomStatus.TRADING);
+
+        // when & then
+        assertThatThrownBy(() -> offeringService.deleteOffering(offering.getId(), proposer))
                 .isInstanceOf(MarketException.class);
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
@@ -1,5 +1,6 @@
 package com.zzang.chongdae.offering.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -73,5 +74,46 @@ public class OfferingServiceTest extends ServiceTest {
 
         // then
         assertEquals(expected, actual);
+    }
+
+    @DisplayName("공모 id와 총대 엔티티가 주어졌을 때 공모를 삭제할 수 있다.")
+    @Test
+    void should_deleteOfferingSoftly_when_givenOfferingIdAndMember() {
+        // given
+        MemberEntity proposer = memberFixture.createMember("ever");
+        OfferingEntity offering = offeringFixture.createOffering(proposer);
+
+        // when
+        offeringService.deleteOffering(offering.getId(), proposer);
+
+        // then
+        assertThat(offeringFixture.countOffering()).isEqualTo(0);
+    }
+
+    @DisplayName("총대가 아닌 사용자가 삭제를 시도할 경우 예외가 발생한다.")
+    @Test
+    void should_throwException_when_deleteWithNotProposer() {
+        // given
+        MemberEntity notProposer = memberFixture.createMember("never");
+        MemberEntity proposer = memberFixture.createMember("ever");
+        OfferingEntity offering = offeringFixture.createOffering(proposer);
+
+        // when & then
+        assertThatThrownBy(() -> offeringService.deleteOffering(offering.getId(), notProposer))
+                .isInstanceOf(MarketException.class);
+    }
+
+    @DisplayName("유효하지 않은 공모 id에 대해 삭제를 시도할 경우 예외가 발생한다.")
+    @Test
+    void should_throwException_when_deleteWithInvalidOfferingId() {
+        // given
+        MemberEntity proposer = memberFixture.createMember("ever");
+        OfferingEntity offering = offeringFixture.createOffering(proposer);
+
+        // when & then
+        long invalidOfferingId = offering.getId() + 9999;
+
+        assertThatThrownBy(() -> offeringService.deleteOffering(invalidOfferingId, proposer))
+                .isInstanceOf(MarketException.class);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #488 
## ✨ 작업 내용
- 공모 삭제 API 구현
### 삭제 정책
- 총대만 삭제 가능
- 거래 진행 중 (확정 후 ~ 완료 전) 삭제 불가능
## 📚 기타
