### PR TITLE
feat: 총대마켓 접근권한 수정

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/auth/config/AuthWebMvcConfig.java
+++ b/backend/src/main/java/com/zzang/chongdae/auth/config/AuthWebMvcConfig.java
@@ -33,7 +33,8 @@ public class AuthWebMvcConfig implements WebMvcConfigurer {
                         "/swagger-ui.html",
                         "/v3/api-docs/swagger-config",
                         "/static/swagger-ui/openapi3.yaml",
-                        "/health-check"
+                        "/health-check",
+                        "/read-only/**"
                 );
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingReadOnlyController.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingReadOnlyController.java
@@ -1,0 +1,49 @@
+package com.zzang.chongdae.offering.controller;
+
+
+import com.zzang.chongdae.offering.service.OfferingService;
+import com.zzang.chongdae.offering.service.dto.OfferingAllResponse;
+import com.zzang.chongdae.offering.service.dto.OfferingAllResponseItem;
+import com.zzang.chongdae.offering.service.dto.OfferingFilterAllResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class OfferingReadOnlyController {
+
+    private static final int MIN_PAGE_SIZE = 1;
+    private static final int MAX_PAGE_SIZE = 60;
+
+    private final OfferingService offeringService;
+
+    @GetMapping("/read-only/offerings")
+    public ResponseEntity<OfferingAllResponse> getAllOffering(
+            @RequestParam(value = "filter", defaultValue = "RECENT") String filterName,
+            @RequestParam(value = "search", required = false) String searchKeyword,
+            @RequestParam(value = "last-id", required = false) Long lastId,
+            @RequestParam(value = "page-size", defaultValue = "10") @Min(MIN_PAGE_SIZE) @Max(MAX_PAGE_SIZE)
+            Integer pageSize) {
+        OfferingAllResponse response = offeringService.getAllOffering(filterName, searchKeyword, lastId, pageSize);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/read-only/offerings/filters")
+    public ResponseEntity<OfferingFilterAllResponse> getAllOfferingFilter() {
+        OfferingFilterAllResponse response = offeringService.getAllOfferingFilter();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/read-only/offerings/{offering-id}")
+    public ResponseEntity<OfferingAllResponseItem> getOffering(
+            @PathVariable(value = "offering-id") Long offeringId) {
+        OfferingAllResponseItem response = offeringService.getOffering(offeringId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
@@ -753,7 +753,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
                 .summary("상품 이미지 업로드")
                 .description("""
                         상품 이미지를 받아 이미지를 S3에 업로드한다.
-                                               
+                        
                         현재 사용 플러그인이 multipart/form-data의 파라미터에 대한 문서화를 지원하지 않습니다.
                         ### Parameters
                         | Part         | Type   | Description            |
@@ -1112,6 +1112,167 @@ public class OfferingIntegrationTest extends IntegrationTest {
                     .when().delete("/offerings/{offering-id}")
                     .then().log().all()
                     .statusCode(204);
+        }
+    }
+
+    @DisplayName("공모 상세 조회(읽기 전용)")
+    @Nested
+    class ReadOnlyGetOffering {
+        List<ParameterDescriptorWithType> pathParameterDescriptors = List.of(
+                parameterWithName("offering-id").description("공모 id (필수)")
+        );
+        List<FieldDescriptor> successResponseDescriptors = List.of(
+                fieldWithPath("id").description("공모 id"),
+                fieldWithPath("title").description("제목"),
+                fieldWithPath("meetingAddressDong").description("모집 동 주소"),
+                fieldWithPath("currentCount").description("현재원"),
+                fieldWithPath("totalCount").description("총원"),
+                fieldWithPath("thumbnailUrl").description("사진 링크"),
+                fieldWithPath("dividedPrice").description("n빵 가격"),
+                fieldWithPath("originPrice").description("원 가격"),
+                fieldWithPath("discountRate").description("할인율"),
+                fieldWithPath("status").description("공모 상태"
+                        + getEnumValuesAsString(OfferingStatus.class)),
+                fieldWithPath("isOpen").description("공모 참여 가능 여부")
+        );
+        ResourceSnippetParameters successSnippets = builder()
+                .summary("공모 단건 조회")
+                .description("공모 단건을 조회합니다.")
+                .pathParameters(pathParameterDescriptors)
+                .responseFields(successResponseDescriptors)
+                .responseSchema(schema("OfferingSuccessResponse"))
+                .build();
+        ResourceSnippetParameters failSnippets = builder()
+                .summary("공모 단건 조회")
+                .description("공모 id를 통해 공모의 단건 정보를 조회합니다.")
+                .pathParameters(pathParameterDescriptors)
+                .responseFields(failResponseDescriptors)
+                .responseSchema(schema("OfferingFailResponse"))
+                .build();
+
+        MemberEntity proposer;
+
+        @BeforeEach
+        void setUp() {
+            proposer = memberFixture.createMember("dora");
+            OfferingEntity offering = offeringFixture.createOffering(proposer);
+            offeringMemberFixture.createProposer(proposer, offering);
+        }
+
+        @DisplayName("공모 단건을 조회할 수 있다")
+        @Test
+        void should_responseOffering_when_givenOfferingId() {
+            given(spec).log().all()
+                    .filter(document("get-offering-success", resource(successSnippets)))
+                    .pathParam("offering-id", 1)
+                    .when().get("/read-only/offerings/{offering-id}")
+                    .then().log().all()
+                    .statusCode(200);
+        }
+
+        @DisplayName("유효하지 않은 공모를 단건 조회할 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_invalidOffering() {
+            given(spec).log().all()
+                    .filter(document("get-offering-fail-invalid-offering", resource(failSnippets)))
+                    .pathParam("offering-id", 100)
+                    .when().get("/read-only/offerings/{offering-id}")
+                    .then().log().all()
+                    .statusCode(400);
+        }
+    }
+
+    @DisplayName("공모 목록 조회(읽기 전용)")
+    @Nested
+    class ReadOnlyGetAllOffering {
+
+        List<ParameterDescriptorWithType> queryParameterDescriptors = List.of(
+                parameterWithName("filter").description("필터 이름 (기본값: RECENT)"
+                        + getEnumValuesAsString(OfferingFilter.class)).optional(),
+                parameterWithName("search").description("검색어").optional(),
+                parameterWithName("last-id").description("마지막 공모 id").optional(),
+                parameterWithName("page-size").description("페이지 크기 (기본값: 10)").optional()
+        );
+        List<FieldDescriptor> successResponseDescriptors = List.of(
+                fieldWithPath("offerings[].id").description("공모 id"),
+                fieldWithPath("offerings[].title").description("제목"),
+                fieldWithPath("offerings[].meetingAddressDong").description("모집 동 주소"),
+                fieldWithPath("offerings[].currentCount").description("현재원"),
+                fieldWithPath("offerings[].totalCount").description("총원"),
+                fieldWithPath("offerings[].thumbnailUrl").description("사진 링크"),
+                fieldWithPath("offerings[].dividedPrice").description("n빵 가격"),
+                fieldWithPath("offerings[].originPrice").description("원 가격"),
+                fieldWithPath("offerings[].discountRate").description("할인율"),
+                fieldWithPath("offerings[].status").description("공모 상태"
+                        + getEnumValuesAsString(OfferingStatus.class)),
+                fieldWithPath("offerings[].isOpen").description("공모 참여 가능 여부")
+        );
+        ResourceSnippetParameters successSnippets = builder()
+                .summary("공모 목록 조회")
+                .description("공모 목록을 조회합니다.")
+                .queryParameters(queryParameterDescriptors)
+                .responseFields(successResponseDescriptors)
+                .responseSchema(schema("OfferingAllSuccessResponse"))
+                .build();
+
+        MemberEntity member;
+
+        @BeforeEach
+        void setUp() {
+            member = memberFixture.createMember("dora");
+            for (int i = 0; i < 11; i++) {
+                offeringFixture.createOffering(member);
+            }
+        }
+
+        @DisplayName("공모 목록을 조회할 수 있다")
+        @Test
+        void should_responseAllOffering_when_givenPageInfo() {
+            given(spec).log().all()
+                    .filter(document("get-all-offering-success", resource(successSnippets)))
+                    .queryParam("filter", "RECENT")
+                    .queryParam("search", "title")
+                    .queryParam("last-id", 10)
+                    .queryParam("page-size", 10)
+                    .when().get("/read-only/offerings")
+                    .then().log().all()
+                    .statusCode(200);
+        }
+    }
+
+    @DisplayName("공모 필터 목록 조회(읽기 전용)")
+    @Nested
+    class ReadOnlyGetAllOfferingFilter {
+
+        List<FieldDescriptor> successResponseDescriptors = List.of(
+                fieldWithPath("filters[].name").description("필터 이름"
+                        + getEnumValuesAsString(OfferingFilter.class)),
+                fieldWithPath("filters[].value").description("필터 디스플레이 이름"),
+                fieldWithPath("filters[].type").description("필터 디스플레이 여부"
+                        + getEnumValuesAsString(OfferingFilterType.class))
+        );
+        ResourceSnippetParameters successSnippets = builder()
+                .summary("공모 필터 목록 조회")
+                .description("공모 목록 조회 시 필터링할 수 있는 키워드 목록을 조회합니다.")
+                .responseFields(successResponseDescriptors)
+                .responseSchema(schema("OfferingFilterSuccessResponse"))
+                .build();
+
+        private MemberEntity member;
+
+        @BeforeEach
+        void setUp() {
+            member = memberFixture.createMember("dora");
+        }
+
+        @DisplayName("공모 id로 공모 일정 정보를 조회할 수 있다")
+        @Test
+        void should_responseOfferingFilter_when_givenOfferingId() {
+            given(spec).log().all()
+                    .filter(document("get-all-offering-filter-success", resource(successSnippets)))
+                    .when().get("/read-only/offerings/filters")
+                    .then().log().all()
+                    .statusCode(200);
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #507 
## ✨ 작업 내용
- 총대마켓 앱을 홍보하기 위해 웹에서 사용할 API를 추가했습니다.
- ⚠️ **해당 API는 쿠키 없이 접근 가능합니다.**
- 기존에 제공하는 API의 접근 권한을 수정하는 것 보다 `/read-only`로 시작하는 API end-point를 만들어서 관리하는 것이 편하다고 생각하여 이 구조를 사용하게 되었습니다.
## 📚 기타

혹시 이 설계에 의견 있으면 가감 없이 많은 의견 제시 부탁드립니다 (제발~~)
