### PR TITLE
feat: Offering 쿼리에 Native Query 적용(+ 테스트 코드 수정)

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
@@ -38,7 +38,7 @@ public class CommentService {
 
     @WriterDatabase
     public Long saveComment(CommentSaveRequest request, MemberEntity member) {
-        OfferingEntity offering = offeringRepository.findById(request.offeringId())
+        OfferingEntity offering = offeringRepository.findByIdWithDeleted(request.offeringId())
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateIsJoined(member, offering);
         CommentEntity comment = new CommentEntity(member, offering, request.content());
@@ -81,7 +81,7 @@ public class CommentService {
     public CommentRoomInfoResponse getCommentRoomInfo(Long offeringId, MemberEntity member) {
         OfferingMemberEntity offeringMember = offeringMemberRepository.findByOfferingIdAndMember(offeringId, member)
                 .orElseThrow(() -> new MarketException(OfferingMemberErrorCode.NOT_FOUND));
-        if (offeringRepository.existsById(offeringId)) {
+        if (offeringRepository.existsByIdWithDeleted(offeringId)) {
             return new CommentRoomInfoResponse(offeringMember.getOffering(), offeringMember.getMember());
         }
         return new CommentRoomInfoResponse(offeringMember);
@@ -108,7 +108,7 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public CommentAllResponse getAllComment(Long offeringId, MemberEntity member) {
-        OfferingEntity offering = offeringRepository.findById(offeringId)
+        OfferingEntity offering = offeringRepository.findByIdWithDeleted(offeringId)
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateIsJoined(member, offering);
         List<CommentEntity> comments = commentRepository.findAllByOfferingOrderByCreatedAt(offering);

--- a/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
@@ -81,7 +81,7 @@ public class CommentService {
     public CommentRoomInfoResponse getCommentRoomInfo(Long offeringId, MemberEntity member) {
         OfferingMemberEntity offeringMember = offeringMemberRepository.findByOfferingIdAndMember(offeringId, member)
                 .orElseThrow(() -> new MarketException(OfferingMemberErrorCode.NOT_FOUND));
-        if (offeringRepository.existsByIdWithDeleted(offeringId)) {
+        if (offeringRepository.existsById(offeringId)) {
             return new CommentRoomInfoResponse(offeringMember.getOffering(), offeringMember.getMember());
         }
         return new CommentRoomInfoResponse(offeringMember);

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
@@ -5,11 +5,30 @@ import com.zzang.chongdae.offering.domain.OfferingStatus;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> {
+
+    @Query(value = """
+            SELECT *
+            FROM offering as o
+            WHERE o.id = :offeringId
+            """, nativeQuery = true)
+    Optional<OfferingEntity> findByIdWithDeleted(Long offeringId);
+
+    @Query(value = """
+            SELECT EXISTS(
+                SELECT 1
+                FROM offering as o
+                WHERE o.id = :offeringId
+                LIMIT 1
+            );
+            """, nativeQuery = true)
+    boolean existsByIdWithDeleted(Long offeringId);
 
     @Query("""
             SELECT o

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
@@ -20,16 +20,6 @@ public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> 
             """, nativeQuery = true)
     Optional<OfferingEntity> findByIdWithDeleted(Long offeringId);
 
-    @Query(value = """
-            SELECT EXISTS(
-                SELECT 1
-                FROM offering as o
-                WHERE o.id = :offeringId
-                LIMIT 1
-            );
-            """, nativeQuery = true)
-    boolean existsByIdWithDeleted(Long offeringId);
-
     @Query("""
             SELECT o
             FROM OfferingEntity as o JOIN OfferingMemberEntity as om

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> {
 

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -98,7 +98,7 @@ public class OfferingMemberService {
     }
 
     public ParticipantResponse getAllParticipant(Long offeringId, MemberEntity member) {
-        OfferingEntity offering = offeringRepository.findById(offeringId)
+        OfferingEntity offering = offeringRepository.findByIdWithDeleted(offeringId)
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateParticipants(offering, member);
 

--- a/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/integration/OfferingIntegrationTest.java
@@ -513,7 +513,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
                     "서울특별시 광진구 구의강변로 3길 11",
                     "상세주소아파트",
                     "구의동",
-                    LocalDateTime.parse("2024-10-11T10:00:00"),
+                    LocalDateTime.now().plusDays(1),
                     "내용입니다."
             );
 
@@ -540,7 +540,7 @@ public class OfferingIntegrationTest extends IntegrationTest {
                     "서울특별시 광진구 구의강변로 3길 11",
                     "상세주소아파트",
                     "구의동",
-                    LocalDateTime.parse("2024-10-11T10:00:00"),
+                    LocalDateTime.now().plusDays(1),
                     "내용입니다."
             );
 

--- a/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
@@ -336,7 +336,7 @@ public class OfferingServiceTest extends ServiceTest {
                     "서울특별시 광진구 구의강변로 3길 11",
                     "상세주소아파트",
                     "구의동",
-                    LocalDateTime.parse("2024-10-11T10:00:00"),
+                    LocalDateTime.now().plusDays(1),
                     "내용입니다."
             );
             Long expected = 1L;


### PR DESCRIPTION
## 📌 관련 이슈
close #548 
## ✨ 작업 내용
- 삭제한 Offering도 검증에 사용할 수 있도록 findById를 findByIdWithDeleted로 교체하고, 필요한 부분에 교체하였다.
- Native Query로 `is_deleted = false`가 붙지 않도록 구현하였다.
- 더불어 테스트 코드에 날짜가 하드 코딩되어 fail하는 테스트에 대해, 항상 실행 일시 기준 내일의 값을 넣을 수 있도록 수정하였다.
## 📚 기타
실패하지 않는 커밋을 만들기 위해 테스트 코드 수정도 추가했습니다.