### PR TITLE
chore: develop 브랜치에서 CI CD가 돌도록 수정

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Android CI CD
 on:
   pull_request:
     branches:
-      - "develop-AN"
+      - "develop"
       - "release*"
 
 defaults:


### PR DESCRIPTION
## 📌 관련 이슈
close #568 
## ✨ 작업 내용
develop 브랜치에서 CI CD가 돌도록 수정
## 📚 기타
