### PR TITLE
fix: 모집 마감 상태 스타일 미적용 해결

### DIFF
--- a/backend/src/main/resources/templates/index.html
+++ b/backend/src/main/resources/templates/index.html
@@ -279,7 +279,7 @@
                 if (offering.status === 'IMMINENT') {
                     statusClass = 'status-imminent';
                     statusName = '마감임박';
-                } else if (offering.status === 'CLOSED') {
+                } else if (offering.status === 'CONFIRMED') {
                     statusClass = 'status-closed';
                     statusName = '모집마감';
                 } else if (offering.status === 'FULL') {


### PR DESCRIPTION
## 📌 관련 이슈
close #590 
## ✨ 작업 내용
- web에서 인원 만석, 모집 마감 상태가 제대로 반영되지 않은 문제가 있었어요~
- 없는 상태값인 CLOSED를 비교해서 스타일이 제대로 적용되지 않았어요
- OfferingStatus 값을 확인하고 CLOSED를 CONFIRMED로 변경해서 해결했습니다~

<img width="264" alt="image" src="https://github.com/user-attachments/assets/d148aed5-18bb-4e23-9c5f-b9624b7dcb12">


## 📚 기타
