### PR TITLE
refactor: 공모 상세 페이지 진입 시 로딩이 된 후에 화면을 보여주도록 수정

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -33,7 +33,8 @@ android {
         versionName = "1.1.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        testInstrumentationRunnerArguments["runnerBuilder"] = "de.mannodermaus.junit5.AndroidJUnit5Builder"
+        testInstrumentationRunnerArguments["runnerBuilder"] =
+            "de.mannodermaus.junit5.AndroidJUnit5Builder"
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -168,6 +169,9 @@ dependencies {
     // Hilt
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
+
+    // Skeleton-UI
+    implementation(libs.shimmer)
 }
 
 kapt {

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailFragment.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailFragment.kt
@@ -116,7 +116,8 @@ class OfferingDetailFragment : Fragment(), OnOfferingDeleteAlertClickListener {
 
         viewModel.showAlertEvent.observe(viewLifecycleOwner) {
             val alertBinding = DialogAlertBinding.inflate(layoutInflater, null, false)
-            alertBinding.tvDialogMessage.text = getString(R.string.offering_detail_participate_alert)
+            alertBinding.tvDialogMessage.text =
+                getString(R.string.offering_detail_participate_alert)
             alertBinding.listener = viewModel
 
             dialog.setContentView(alertBinding.root)
@@ -125,6 +126,10 @@ class OfferingDetailFragment : Fragment(), OnOfferingDeleteAlertClickListener {
 
         viewModel.alertCancelEvent.observe(viewLifecycleOwner) {
             dialog.dismiss()
+        }
+
+        viewModel.loading.observe(viewLifecycleOwner) {
+            startShimmer(it)
         }
     }
 
@@ -205,6 +210,20 @@ class OfferingDetailFragment : Fragment(), OnOfferingDeleteAlertClickListener {
                 Toast.LENGTH_SHORT,
             )
         toast?.show()
+    }
+
+    private fun startShimmer(isLoading: Boolean) {
+        if (isLoading) {
+            binding.sflOfferingDetail.startShimmer()
+            binding.sflOfferingDetail.visibility = View.VISIBLE
+            binding.svLayout.visibility = View.GONE
+            binding.btnParticipate.visibility = View.GONE
+            binding.btnMoveCommentDetail.visibility = View.GONE
+        } else {
+            binding.sflOfferingDetail.stopShimmer()
+            binding.sflOfferingDetail.visibility = View.GONE
+            binding.svLayout.visibility = View.VISIBLE
+        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailFragment.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailFragment.kt
@@ -215,9 +215,15 @@ class OfferingDetailFragment : Fragment(), OnOfferingDeleteAlertClickListener {
     private fun startShimmer(isLoading: Boolean) {
         if (isLoading) {
             binding.sflOfferingDetail.startShimmer()
-            return
+            binding.sflOfferingDetail.visibility = View.VISIBLE
+            binding.svLayout.visibility = View.GONE
+            binding.btnParticipate.visibility = View.GONE
+            binding.btnMoveCommentDetail.visibility = View.GONE
+        } else {
+            binding.sflOfferingDetail.stopShimmer()
+            binding.sflOfferingDetail.visibility = View.GONE
+            binding.svLayout.visibility = View.VISIBLE
         }
-        binding.sflOfferingDetail.stopShimmer()
     }
 
     companion object {

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailFragment.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailFragment.kt
@@ -215,15 +215,9 @@ class OfferingDetailFragment : Fragment(), OnOfferingDeleteAlertClickListener {
     private fun startShimmer(isLoading: Boolean) {
         if (isLoading) {
             binding.sflOfferingDetail.startShimmer()
-            binding.sflOfferingDetail.visibility = View.VISIBLE
-            binding.svLayout.visibility = View.GONE
-            binding.btnParticipate.visibility = View.GONE
-            binding.btnMoveCommentDetail.visibility = View.GONE
-        } else {
-            binding.sflOfferingDetail.stopShimmer()
-            binding.sflOfferingDetail.visibility = View.GONE
-            binding.svLayout.visibility = View.VISIBLE
+            return
         }
+        binding.sflOfferingDetail.stopShimmer()
     }
 
     companion object {

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailViewModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailViewModel.kt
@@ -23,6 +23,7 @@ import com.zzang.chongdae.presentation.view.common.OnAlertClickListener
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class OfferingDetailViewModel
@@ -105,6 +106,7 @@ class OfferingDetailViewModel
         fun loadOffering() {
             viewModelScope.launch {
                 _loading.value = true
+                delay(3000)
                 when (val result = offeringDetailRepository.fetchOfferingDetail(offeringId)) {
                     is Result.Error ->
                         when (result.error) {

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailViewModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/offeringdetail/OfferingDetailViewModel.kt
@@ -23,7 +23,6 @@ import com.zzang.chongdae.presentation.view.common.OnAlertClickListener
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class OfferingDetailViewModel
@@ -106,7 +105,6 @@ class OfferingDetailViewModel
         fun loadOffering() {
             viewModelScope.launch {
                 _loading.value = true
-                delay(3000)
                 when (val result = offeringDetailRepository.fetchOfferingDetail(offeringId)) {
                     is Result.Error ->
                         when (result.error) {

--- a/android/app/src/main/res/layout/fragment_offering_detail.xml
+++ b/android/app/src/main/res/layout/fragment_offering_detail.xml
@@ -22,6 +22,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:overScrollMode="never"
+            app:isVisible="@{!vm.loading}"
             android:scrollbars="none"
             app:layout_constraintBottom_toTopOf="@id/btn_participate"
             app:layout_constraintEnd_toEndOf="parent"
@@ -362,7 +363,7 @@
             app:condition="@{vm.offeringCondition}"
             app:currentCount="@{vm.currentCount}"
             app:debouncedOnClick="@{() -> vm.onParticipateClick()}"
-            app:isVisible="@{!vm.isParticipated}"
+            app:isVisible="@{!vm.isParticipated  &amp;&amp; !vm.loading}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -382,7 +383,7 @@
             android:text="@string/offering_detail_move_comment_detail"
             android:textColor="@color/white"
             app:debouncedOnClick="@{() -> vm.onClickMoveCommentDetail()}"
-            app:isVisible="@{vm.isParticipated}"
+            app:isVisible="@{vm.isParticipated  &amp;&amp; !vm.loading}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -392,6 +393,7 @@
             android:id="@+id/sfl_offering_detail"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            app:isVisible="@{vm.loading}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 

--- a/android/app/src/main/res/layout/fragment_offering_detail.xml
+++ b/android/app/src/main/res/layout/fragment_offering_detail.xml
@@ -23,6 +23,7 @@
             android:layout_height="0dp"
             android:overScrollMode="never"
             android:scrollbars="none"
+            app:isVisible="@{!vm.loading}"
             app:layout_constraintBottom_toTopOf="@id/btn_participate"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -362,7 +363,7 @@
             app:condition="@{vm.offeringCondition}"
             app:currentCount="@{vm.currentCount}"
             app:debouncedOnClick="@{() -> vm.onParticipateClick()}"
-            app:isVisible="@{!vm.isParticipated}"
+            app:isVisible="@{vm.isParticipated &amp;&amp; !vm.loading}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -382,7 +383,7 @@
             android:text="@string/offering_detail_move_comment_detail"
             android:textColor="@color/white"
             app:debouncedOnClick="@{() -> vm.onClickMoveCommentDetail()}"
-            app:isVisible="@{vm.isParticipated}"
+            app:isVisible="@{vm.isParticipated &amp;&amp; !vm.loading}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -392,6 +393,7 @@
             android:id="@+id/sfl_offering_detail"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            app:isVisible="@{vm.loading}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 

--- a/android/app/src/main/res/layout/fragment_offering_detail.xml
+++ b/android/app/src/main/res/layout/fragment_offering_detail.xml
@@ -22,7 +22,6 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:overScrollMode="never"
-            app:isVisible="@{!vm.loading}"
             android:scrollbars="none"
             app:layout_constraintBottom_toTopOf="@id/btn_participate"
             app:layout_constraintEnd_toEndOf="parent"
@@ -363,7 +362,7 @@
             app:condition="@{vm.offeringCondition}"
             app:currentCount="@{vm.currentCount}"
             app:debouncedOnClick="@{() -> vm.onParticipateClick()}"
-            app:isVisible="@{!vm.isParticipated  &amp;&amp; !vm.loading}"
+            app:isVisible="@{!vm.isParticipated}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -383,7 +382,7 @@
             android:text="@string/offering_detail_move_comment_detail"
             android:textColor="@color/white"
             app:debouncedOnClick="@{() -> vm.onClickMoveCommentDetail()}"
-            app:isVisible="@{vm.isParticipated  &amp;&amp; !vm.loading}"
+            app:isVisible="@{vm.isParticipated}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -393,7 +392,6 @@
             android:id="@+id/sfl_offering_detail"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:isVisible="@{vm.loading}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 

--- a/android/app/src/main/res/layout/fragment_offering_detail.xml
+++ b/android/app/src/main/res/layout/fragment_offering_detail.xml
@@ -388,5 +388,16 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/sv_layout" />
 
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/sfl_offering_detail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <include layout="@layout/fragment_offering_detail_shimmer" />
+
+        </com.facebook.shimmer.ShimmerFrameLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_offering_detail_shimmer.xml
+++ b/android/app/src/main/res/layout/fragment_offering_detail_shimmer.xml
@@ -5,18 +5,18 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".presentation.view.offeringdetail.OfferingDetailFragment">
+        android:layout_height="match_parent">
 
         <ImageView
             android:id="@+id/iv_product"
             android:layout_width="match_parent"
             android:layout_height="250dp"
             android:adjustViewBounds="true"
+            android:background="@color/gray_300"
             android:scaleType="centerCrop"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="`parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
 
@@ -25,7 +25,8 @@
             android:layout_width="@dimen/size_200"
             android:layout_height="@dimen/size_44"
             android:layout_marginStart="23dp"
-            android:layout_marginTop="44dp"
+            android:layout_marginTop="18dp"
+            android:background="@color/gray_300"
             android:paddingBottom="12dp"
             app:layout_constraintBottom_toTopOf="@id/iv_user_emoticon"
             app:layout_constraintStart_toStartOf="parent"
@@ -33,9 +34,8 @@
 
         <ImageView
             android:id="@+id/iv_user_emoticon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:src="@drawable/ic_detail_user"
+            android:layout_width="15dp"
+            android:layout_height="11dp"
             app:layout_constraintStart_toStartOf="@id/tv_title"
             app:layout_constraintTop_toBottomOf="@id/tv_title" />
 
@@ -76,7 +76,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="15dp"
-            android:src="@drawable/ic_detail_money"
             app:layout_constraintStart_toStartOf="@id/tv_title"
             app:layout_constraintTop_toBottomOf="@id/horizon_line" />
 
@@ -114,7 +113,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="23dp"
-            android:src="@drawable/ic_detail_clock"
             app:layout_constraintStart_toStartOf="@id/tv_title"
             app:layout_constraintTop_toBottomOf="@id/tv_divided_price" />
 
@@ -142,7 +140,6 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="60dp"
             android:layout_marginTop="23dp"
-            android:src="@drawable/ic_detail_location"
             app:layout_constraintStart_toEndOf="@id/tv_meeting_date_comment"
             app:layout_constraintTop_toBottomOf="@id/tv_divided_price" />
 
@@ -180,6 +177,7 @@
             android:layout_height="@dimen/size_150"
             android:layout_marginTop="18dp"
             android:layout_marginEnd="18dp"
+            android:background="@color/gray_300"
             android:paddingBottom="@dimen/size_50"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@id/tv_title"

--- a/android/app/src/main/res/layout/fragment_offering_detail_shimmer.xml
+++ b/android/app/src/main/res/layout/fragment_offering_detail_shimmer.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.view.offeringdetail.OfferingDetailFragment">
+
+        <ImageView
+            android:id="@+id/iv_product"
+            android:layout_width="match_parent"
+            android:layout_height="250dp"
+            android:adjustViewBounds="true"
+            android:scaleType="centerCrop"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="`parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="@dimen/size_200"
+            android:layout_height="@dimen/size_44"
+            android:layout_marginStart="23dp"
+            android:layout_marginTop="44dp"
+            android:paddingBottom="12dp"
+            app:layout_constraintBottom_toTopOf="@id/iv_user_emoticon"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_product" />
+
+        <ImageView
+            android:id="@+id/iv_user_emoticon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_detail_user"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+        <TextView
+            android:id="@+id/tv_nickname"
+            android:layout_width="@dimen/size_80"
+            android:layout_height="@dimen/size_20"
+            android:layout_marginStart="8dp"
+            android:fontFamily="@font/suit_medium"
+            android:textColor="@color/gray_900"
+            android:textSize="14sp"
+            app:layout_constraintStart_toEndOf="@id/iv_user_emoticon"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+        <TextView
+            android:id="@+id/tv_product_link_comment"
+            android:layout_width="@dimen/size_60"
+            android:layout_height="@dimen/size_20"
+            android:layout_marginTop="18dp"
+            app:layout_constraintBottom_toTopOf="@id/horizon_line"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_nickname" />
+
+
+        <View
+            android:id="@+id/horizon_line"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="12dp"
+            android:background="@color/horizon_line"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_product_link_comment" />
+
+        <ImageView
+            android:id="@+id/iv_money"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="15dp"
+            android:src="@drawable/ic_detail_money"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/horizon_line" />
+
+        <TextView
+            android:id="@+id/tv_moeny_comment"
+            android:layout_width="@dimen/size_50"
+            android:layout_height="@dimen/size_18"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="15dp"
+            app:layout_constraintBottom_toBottomOf="@id/iv_money"
+            app:layout_constraintStart_toEndOf="@id/iv_money"
+            app:layout_constraintTop_toBottomOf="@id/horizon_line" />
+
+        <TextView
+            android:id="@+id/tv_divided_price"
+            android:layout_width="@dimen/size_70"
+            android:layout_height="@dimen/size_24"
+            android:layout_marginTop="8dp"
+            android:textSize="18sp"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/iv_money" />
+
+        <TextView
+            android:id="@+id/tv_total_price"
+            android:layout_width="@dimen/size_80"
+            android:layout_height="@dimen/size_15"
+            android:layout_marginStart="5dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintBottom_toBottomOf="@id/tv_divided_price"
+            app:layout_constraintStart_toEndOf="@id/tv_divided_price"
+            app:layout_constraintTop_toBottomOf="@id/iv_money" />
+
+        <ImageView
+            android:id="@+id/iv_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="23dp"
+            android:src="@drawable/ic_detail_clock"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_divided_price" />
+
+        <TextView
+            android:id="@+id/tv_meeting_date_comment"
+            android:layout_width="@dimen/size_60"
+            android:layout_height="@dimen/size_20"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="23dp"
+            app:layout_constraintBottom_toBottomOf="@id/iv_time"
+            app:layout_constraintStart_toEndOf="@id/iv_time"
+            app:layout_constraintTop_toBottomOf="@id/tv_divided_price" />
+
+        <TextView
+            android:id="@+id/tv_meeting_date"
+            android:layout_width="90dp"
+            android:layout_height="@dimen/size_18"
+            android:layout_marginTop="8dp"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/iv_time" />
+
+        <ImageView
+            android:id="@+id/iv_location"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="60dp"
+            android:layout_marginTop="23dp"
+            android:src="@drawable/ic_detail_location"
+            app:layout_constraintStart_toEndOf="@id/tv_meeting_date_comment"
+            app:layout_constraintTop_toBottomOf="@id/tv_divided_price" />
+
+        <TextView
+            android:id="@+id/tv_recruit_location_comment"
+            android:layout_width="90dp"
+            android:layout_height="@dimen/size_18"
+            android:layout_marginTop="23dp"
+            app:layout_constraintBottom_toBottomOf="@id/iv_location"
+            app:layout_constraintStart_toEndOf="@id/iv_location"
+            app:layout_constraintTop_toBottomOf="@id/tv_divided_price" />
+
+        <TextView
+            android:id="@+id/tv_meeting_address"
+            android:layout_width="@dimen/size_70"
+            android:layout_height="@dimen/size_18"
+            android:layout_marginTop="8dp"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:paddingEnd="@dimen/size_5"
+            app:layout_constraintStart_toStartOf="@id/iv_location"
+            app:layout_constraintTop_toBottomOf="@id/iv_location" />
+
+        <TextView
+            android:id="@+id/tv_content_comment"
+            android:layout_width="@dimen/size_40"
+            android:layout_height="@dimen/size_20"
+            android:layout_marginTop="30dp"
+            app:layout_constraintStart_toStartOf="@id/tv_meeting_date"
+            app:layout_constraintTop_toBottomOf="@id/tv_meeting_date" />
+
+        <TextView
+            android:id="@+id/tv_content"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/size_150"
+            android:layout_marginTop="18dp"
+            android:layout_marginEnd="18dp"
+            android:paddingBottom="@dimen/size_50"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_content_comment" />
+
+        <Button
+            android:id="@+id/btn_participate"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/size_60"
+            android:layout_marginHorizontal="19dp"
+            android:layout_marginBottom="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ paging = "3.3.0"
 swiperefreshlayout = "1.1.0"
 datastore = "1.0.0"
 junit-jupiter = "5.10.2"
+shimmer = "0.5.0"
 #assert-core = "3.25.3"
 #core-testing = "2.1.0"
 #mannodermaus = "1.3.0"
@@ -97,6 +98,9 @@ kakao-sdk = { group = "com.kakao.sdk", name = "v2-all", version.ref = "kakaoSdk"
 
 # Kotlin Serialization
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+
+# Skeleton-UI
+shimmer = { group = "com.facebook.shimmer", name = "shimmer", version.ref = "shimmer" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 📌 관련 이슈
close #544 
## ✨ 작업 내용
- 로딩 상태를 추가하여 로딩이 완료 된 경우 공모 상세 페이지를 보여주도록 하였습니다.
- facebook의 skeleton ui라이브러리를 사용하였습니다.
- 의존성 추가해주었습니다.
```kotlin
    // Skeleton-UI
    implementation(libs.shimmer)
```

## 📚 기타

### Before

https://github.com/user-attachments/assets/80d93097-ae50-426a-93cd-443e46951b75



### After
[deleay 3초]

https://github.com/user-attachments/assets/a2cca046-ac25-476d-83fd-6fa8e09b64bf

[delay X]


https://github.com/user-attachments/assets/9c53356b-eb71-4149-a30f-7cfb12f5e701

