### PR TITLE
refactor: 데이터베이스 락을 통해 중복 참여 방지

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
@@ -1,13 +1,11 @@
 package com.zzang.chongdae.offering.repository;
 
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
-import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> {
@@ -129,8 +127,4 @@ public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> 
                 AND (o.offeringStatus IN ('AVAILABLE', 'FULL', 'IMMINENT'))
             """)
     List<OfferingEntity> findByMeetingDateAndOfferingStatusNotConfirmed(LocalDateTime meetingDate);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT o FROM OfferingEntity o WHERE o.id = :id")
-    Optional<OfferingEntity> findByIdWithLock(Long id);
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
@@ -1,6 +1,5 @@
 package com.zzang.chongdae.offering.repository;
 
-import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,14 +16,6 @@ public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> 
             WHERE o.id = :offeringId
             """, nativeQuery = true)
     Optional<OfferingEntity> findByIdWithDeleted(Long offeringId);
-
-    @Query("""
-            SELECT o
-            FROM OfferingEntity as o JOIN OfferingMemberEntity as om
-                ON o.id = om.offering.id
-            WHERE om.member = :member
-            """)
-    List<OfferingEntity> findCommentRoomsByMember(MemberEntity member);
 
     @Query("""
             SELECT o

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
@@ -1,11 +1,13 @@
 package com.zzang.chongdae.offering.repository;
 
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> {
@@ -127,4 +129,8 @@ public interface OfferingRepository extends JpaRepository<OfferingEntity, Long> 
                 AND (o.offeringStatus IN ('AVAILABLE', 'FULL', 'IMMINENT'))
             """)
     List<OfferingEntity> findByMeetingDateAndOfferingStatusNotConfirmed(LocalDateTime meetingDate);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM OfferingEntity o WHERE o.id = :id")
+    Optional<OfferingEntity> findByIdWithLock(Long id);
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
@@ -18,6 +18,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -107,6 +108,9 @@ public class OfferingEntity extends BaseTimeEntity {
     @ColumnDefault("false")
     private Boolean isDeleted;
 
+    @Version
+    private Long version;
+
     public OfferingEntity(MemberEntity member, String title, String description, String thumbnailUrl, String productUrl,
                           LocalDateTime meetingDate, String meetingAddress, String meetingAddressDetail,
                           String meetingAddressDong,
@@ -115,7 +119,7 @@ public class OfferingEntity extends BaseTimeEntity {
                           OfferingStatus offeringStatus, CommentRoomStatus roomStatus) {
         this(null, member, title, description, thumbnailUrl, productUrl, meetingDate, meetingAddress,
                 meetingAddressDetail, meetingAddressDong, totalCount, currentCount, totalPrice,
-                originPrice, discountRate, offeringStatus, roomStatus, false);
+                originPrice, discountRate, offeringStatus, roomStatus, false, 1L);
     }
 
     public void participate() {

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
@@ -120,10 +120,14 @@ public class OfferingEntity extends BaseTimeEntity {
 
     public void participate() {
         currentCount++;
+        OfferingStatus offeringStatus = toOfferingJoinedCount().decideOfferingStatus();
+        updateOfferingStatus(offeringStatus);
     }
 
     public void leave() {
         currentCount--;
+        OfferingStatus offeringStatus = toOfferingJoinedCount().decideOfferingStatus();
+        updateOfferingStatus(offeringStatus);
     }
 
     public CommentRoomStatus moveCommentRoomStatus() {

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
@@ -36,7 +36,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EqualsAndHashCode(of = "id", callSuper = false)
-@SQLDelete(sql = "UPDATE offering SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE offering SET is_deleted = true, version = version + 1 WHERE id = ? and version = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "offering")
 @Entity

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
@@ -18,7 +18,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Version;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -36,7 +35,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EqualsAndHashCode(of = "id", callSuper = false)
-@SQLDelete(sql = "UPDATE offering SET is_deleted = true, version = version + 1 WHERE id = ? and version = ?")
+@SQLDelete(sql = "UPDATE offering SET is_deleted = true WHERE id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "offering")
 @Entity
@@ -108,9 +107,6 @@ public class OfferingEntity extends BaseTimeEntity {
     @ColumnDefault("false")
     private Boolean isDeleted;
 
-    @Version
-    private Long version;
-
     public OfferingEntity(MemberEntity member, String title, String description, String thumbnailUrl, String productUrl,
                           LocalDateTime meetingDate, String meetingAddress, String meetingAddressDetail,
                           String meetingAddressDong,
@@ -119,7 +115,7 @@ public class OfferingEntity extends BaseTimeEntity {
                           OfferingStatus offeringStatus, CommentRoomStatus roomStatus) {
         this(null, member, title, description, thumbnailUrl, productUrl, meetingDate, meetingAddress,
                 meetingAddressDetail, meetingAddressDong, totalCount, currentCount, totalPrice,
-                originPrice, discountRate, offeringStatus, roomStatus, false, 1L);
+                originPrice, discountRate, offeringStatus, roomStatus, false);
     }
 
     public void participate() {

--- a/backend/src/main/java/com/zzang/chongdae/offering/service/OfferingService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/service/OfferingService.java
@@ -132,13 +132,13 @@ public class OfferingService {
     public Long saveOffering(OfferingSaveRequest request, MemberEntity member) {
         OfferingEntity offering = request.toEntity(member);
         validateMeetingDate(offering.getMeetingDate());
-        OfferingEntity savedOffering = offeringRepository.save(offering);
+        OfferingEntity saved = offeringRepository.save(offering);
 
-        OfferingMemberEntity offeringMember = new OfferingMemberEntity(member, offering, OfferingMemberRole.PROPOSER);
+        OfferingMemberEntity offeringMember = new OfferingMemberEntity(member, saved, OfferingMemberRole.PROPOSER);
         offeringMemberRepository.save(offeringMember);
 
-        eventPublisher.publishEvent(new SaveOfferingEvent(this, savedOffering));
-        return savedOffering.getId();
+        eventPublisher.publishEvent(new SaveOfferingEvent(this, saved));
+        return saved.getId();
     }
 
     private void validateMeetingDate(LocalDateTime offeringMeetingDateTime) {

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -36,7 +36,7 @@ public class OfferingMemberService {
     @WriterDatabase
     @Transactional
     public Long participate(ParticipationRequest request, MemberEntity member) {
-        OfferingEntity offering = offeringRepository.findByIdWithLock(request.offeringId())
+        OfferingEntity offering = offeringRepository.findById(request.offeringId())
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateParticipate(offering, member);
 

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -6,7 +6,6 @@ import com.zzang.chongdae.global.config.WriterDatabase;
 import com.zzang.chongdae.global.exception.MarketException;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offering.domain.CommentRoomStatus;
-import com.zzang.chongdae.offering.domain.OfferingStatus;
 import com.zzang.chongdae.offering.exception.OfferingErrorCode;
 import com.zzang.chongdae.offering.repository.OfferingRepository;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
@@ -44,13 +43,10 @@ public class OfferingMemberService {
         OfferingMemberEntity offeringMember = new OfferingMemberEntity(
                 member, offering, OfferingMemberRole.PARTICIPANT);
         OfferingMemberEntity saved = offeringMemberRepository.save(offeringMember);
-
         offering.participate();
-        OfferingStatus offeringStatus = offering.toOfferingJoinedCount().decideOfferingStatus();
-        offering.updateOfferingStatus(offeringStatus);
 
         eventPublisher.publishEvent(new ParticipateEvent(this, saved));
-        return offeringMember.getId();
+        return saved.getId();
     }
 
     private void validateParticipate(OfferingEntity offering, MemberEntity member) {
@@ -78,11 +74,10 @@ public class OfferingMemberService {
         OfferingMemberEntity offeringMember = offeringMemberRepository.findByOfferingAndMember(offering, member)
                 .orElseThrow(() -> new MarketException(OfferingMemberErrorCode.PARTICIPANT_NOT_FOUND));
         validateCancel(offeringMember);
-        offeringMemberRepository.delete(offeringMember);
 
+        offeringMemberRepository.delete(offeringMember);
         offering.leave();
-        OfferingStatus offeringStatus = offering.toOfferingJoinedCount().decideOfferingStatus();
-        offering.updateOfferingStatus(offeringStatus);
+
         eventPublisher.publishEvent(new CancelParticipateEvent(this, offeringMember));
     }
 

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -36,7 +36,7 @@ public class OfferingMemberService {
     @WriterDatabase
     @Transactional
     public Long participate(ParticipationRequest request, MemberEntity member) {
-        OfferingEntity offering = offeringRepository.findById(request.offeringId())
+        OfferingEntity offering = offeringRepository.findByIdWithLock(request.offeringId())
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateParticipate(offering, member);
 

--- a/backend/src/test/java/com/zzang/chongdae/global/domain/OfferingFixture.java
+++ b/backend/src/test/java/com/zzang/chongdae/global/domain/OfferingFixture.java
@@ -17,6 +17,7 @@ public class OfferingFixture {
 
     private OfferingEntity createOffering(MemberEntity member,
                                           String title,
+                                          Integer totalCount,
                                           Double discountRate,
                                           OfferingStatus offeringStatus,
                                           CommentRoomStatus commentRoomStatus) {
@@ -30,10 +31,10 @@ public class OfferingFixture {
                 "meetingAddress",
                 "meetingAddressDetail",
                 "meetingAddressDong",
-                5,
+                totalCount,
                 1,
                 5000,
-                1000,
+                10_000,
                 discountRate,
                 offeringStatus,
                 commentRoomStatus
@@ -42,23 +43,27 @@ public class OfferingFixture {
     }
 
     public OfferingEntity createOffering(MemberEntity member, Double discountRate) {
-        return createOffering(member, "title", discountRate, OfferingStatus.AVAILABLE, CommentRoomStatus.GROUPING);
+        return createOffering(member, "title", 5, discountRate, OfferingStatus.AVAILABLE, CommentRoomStatus.GROUPING);
     }
 
     public OfferingEntity createOffering(MemberEntity member, CommentRoomStatus commentRoomStatus) {
-        return createOffering(member, "title", 33.3, OfferingStatus.AVAILABLE, commentRoomStatus);
+        return createOffering(member, "title", 5, 33.3, OfferingStatus.AVAILABLE, commentRoomStatus);
     }
 
     public OfferingEntity createOffering(MemberEntity member, OfferingStatus offeringStatus) {
-        return createOffering(member, "title", 33.3, offeringStatus, CommentRoomStatus.GROUPING);
+        return createOffering(member, "title", 5, 33.3, offeringStatus, CommentRoomStatus.GROUPING);
     }
 
     public OfferingEntity createOffering(MemberEntity member) {
-        return createOffering(member, "title", 33.3, OfferingStatus.AVAILABLE, CommentRoomStatus.GROUPING);
+        return createOffering(member, "title", 5, 33.3, OfferingStatus.AVAILABLE, CommentRoomStatus.GROUPING);
     }
 
     public OfferingEntity createOffering(MemberEntity member, String title) {
-        return createOffering(member, title, 33.3, OfferingStatus.AVAILABLE, CommentRoomStatus.GROUPING);
+        return createOffering(member, title, 5, 33.3, OfferingStatus.AVAILABLE, CommentRoomStatus.GROUPING);
+    }
+
+    public OfferingEntity createOffering(MemberEntity member, Integer totalCount) {
+        return createOffering(member, "title", totalCount, 33.3, OfferingStatus.AVAILABLE, CommentRoomStatus.GROUPING);
     }
 
     public void deleteOffering(OfferingEntity offering) {

--- a/backend/src/test/java/com/zzang/chongdae/global/helper/ConcurrencyExecutor.java
+++ b/backend/src/test/java/com/zzang/chongdae/global/helper/ConcurrencyExecutor.java
@@ -1,0 +1,116 @@
+package com.zzang.chongdae.global.helper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+public class ConcurrencyExecutor {
+
+    private static ConcurrencyExecutor INSTANCE;
+
+    public static ConcurrencyExecutor getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ConcurrencyExecutor();
+        }
+        return INSTANCE;
+    }
+
+    public void executeWithoutResult(Runnable... tasks) throws InterruptedException {
+        int executeCount = tasks.length;
+        ExecutorService executorService = Executors.newFixedThreadPool(executeCount);
+        CountDownLatch countDownLatch = new CountDownLatch(executeCount);
+
+        for (Runnable task : tasks) {
+            executorService.submit(() -> {
+                try {
+                    task.run();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        countDownLatch.await();
+        executorService.shutdown();
+    }
+
+    public void executeWithoutResult(int repeatCount, Runnable task) throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(repeatCount);
+        CountDownLatch countDownLatch = new CountDownLatch(repeatCount);
+
+        for (int i = 0; i < repeatCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    task.run();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        countDownLatch.await();
+        executorService.shutdown();
+    }
+
+    public final <T> List<T> execute(Supplier<T>... tasks) throws InterruptedException {
+        int executeCount = tasks.length;
+        ExecutorService executorService = Executors.newFixedThreadPool(executeCount);
+        CountDownLatch countDownLatch = new CountDownLatch(executeCount);
+
+        List<Future<T>> result = new ArrayList<>();
+        for (Supplier<T> task : tasks) {
+            Future<T> future = executorService.submit(() -> {
+                try {
+                    return task.get();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+            result.add(future);
+        }
+
+        countDownLatch.await();
+        executorService.shutdown();
+
+        return result.stream()
+                .map(this::getWithoutException)
+                .toList();
+    }
+
+    public <T> List<T> execute(int repeatCount, Supplier<T> task) throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(repeatCount);
+        CountDownLatch countDownLatch = new CountDownLatch(repeatCount);
+
+        List<Future<T>> result = new ArrayList<>();
+        for (int i = 0; i < repeatCount; i++) {
+            Future<T> future = executorService.submit(() -> {
+                try {
+                    return task.get();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+            result.add(future);
+        }
+
+        countDownLatch.await();
+        executorService.shutdown();
+
+        return result.stream()
+                .map(this::getWithoutException)
+                .toList();
+    }
+
+    private <T> T getWithoutException(Future<T> future) {
+        try {
+            return future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("동시 작업 내부 예외 발생: ", e);
+        }
+    }
+}

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceConcurrencyTest.java
@@ -65,7 +65,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
         ParticipationRequest request = new ParticipationRequest(offering.getId());
         MemberEntity participant = memberFixture.createMember("whoever");
 
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
 
         int executeCount = 5;
         CountDownLatch countDownLatch = new CountDownLatch(executeCount);

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceConcurrencyTest.java
@@ -2,14 +2,12 @@ package com.zzang.chongdae.offeringmember.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.zzang.chongdae.global.helper.ConcurrencyExecutor;
 import com.zzang.chongdae.global.service.ServiceTest;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponse;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,22 +29,9 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
         ParticipationRequest request = new ParticipationRequest(offering.getId());
         MemberEntity participant = memberFixture.createMember("whoever");
 
-        int executeCount = 5;
-        ExecutorService executorService = Executors.newFixedThreadPool(executeCount);
-        CountDownLatch countDownLatch = new CountDownLatch(executeCount);
-
-        for (int i = 0; i < executeCount; i++) {
-            executorService.submit(() -> {
-                try {
-                    offeringMemberService.participate(request, participant);
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
-
-        countDownLatch.await();
-        executorService.shutdown();
+        ConcurrencyExecutor concurrencyExecutor = ConcurrencyExecutor.getInstance();
+        concurrencyExecutor.executeWithoutResult(5,
+                () -> offeringMemberService.participate(request, participant));
 
         // then
         ParticipantResponse response = offeringMemberService.getAllParticipant(offering.getId(), proposer);
@@ -66,27 +51,10 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
         MemberEntity participant1 = memberFixture.createMember("ever1");
         MemberEntity participant2 = memberFixture.createMember("ever2");
 
-        int executeCount = 2;
-        ExecutorService executorService = Executors.newFixedThreadPool(executeCount);
-        CountDownLatch countDownLatch = new CountDownLatch(executeCount);
-
-        executorService.submit(() -> {
-            try {
-                offeringMemberService.participate(request, participant1);
-            } finally {
-                countDownLatch.countDown();
-            }
-        });
-        executorService.submit(() -> {
-            try {
-                offeringMemberService.participate(request, participant2);
-            } finally {
-                countDownLatch.countDown();
-            }
-        });
-
-        countDownLatch.await();
-        executorService.shutdown();
+        ConcurrencyExecutor concurrencyExecutor = ConcurrencyExecutor.getInstance();
+        concurrencyExecutor.executeWithoutResult(
+                () -> offeringMemberService.participate(request, participant1),
+                () -> offeringMemberService.participate(request, participant2));
 
         // then
         ParticipantResponse response = offeringMemberService.getAllParticipant(offering.getId(), proposer);

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceConcurrencyTest.java
@@ -10,7 +10,6 @@ import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,40 +19,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
     @Autowired
     private OfferingMemberService offeringMemberService;
 
-    @Disabled
-    @DisplayName("기존 - 동시에 참여할 경우 중복 참여가 가능하다.")
-    @Test
-    void should_participateInDuplicate() throws InterruptedException {
-        // given
-        MemberEntity proposer = memberFixture.createMember("ever");
-        OfferingEntity offering = offeringFixture.createOffering(proposer);
-        offeringMemberFixture.createProposer(proposer, offering);
-
-        // when
-        ParticipationRequest request = new ParticipationRequest(offering.getId());
-        MemberEntity participant = memberFixture.createMember("whoever");
-
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
-
-        int executeCount = 2;
-        CountDownLatch countDownLatch = new CountDownLatch(executeCount);
-
-        for (int i = 0; i < executeCount; i++) {
-            executorService.submit(() -> {
-                offeringMemberService.participate(request, participant);
-                countDownLatch.countDown();
-            });
-        }
-
-        countDownLatch.await();
-        executorService.shutdown();
-
-        // then
-        ParticipantResponse response = offeringMemberService.getAllParticipant(offering.getId(), proposer);
-        assertThat(response.participants()).hasSize(executeCount);
-    }
-
-    @DisplayName("개선 - 같은 사용자가 같은 공모에 동시에 참여할 경우 중복 참여가 불가능하다.")
+    @DisplayName("같은 사용자가 같은 공모에 동시에 참여할 경우 중복 참여가 불가능하다.")
     @Test
     void should_failParticipate_when_givenSameMemberAndSameOffering() throws InterruptedException {
         // given
@@ -65,13 +31,12 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
         ParticipationRequest request = new ParticipationRequest(offering.getId());
         MemberEntity participant = memberFixture.createMember("whoever");
 
-        ExecutorService executorService = Executors.newFixedThreadPool(5);
-
         int executeCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(executeCount);
         CountDownLatch countDownLatch = new CountDownLatch(executeCount);
 
         for (int i = 0; i < executeCount; i++) {
-            executorService.execute(() -> {
+            executorService.submit(() -> {
                 try {
                     offeringMemberService.participate(request, participant);
                 } finally {
@@ -88,7 +53,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
         assertThat(response.participants()).hasSize(1);
     }
 
-    @DisplayName("개선 - 다른 사용자가 같은 공모에 동시에 참여할 경우 중복 참여가 불가능하다.")
+    @DisplayName("다른 사용자가 같은 공모에 동시에 참여할 경우 중복 참여가 불가능하다.")
     @Test
     void should_failParticipate_when_givenDifferentMemberAndSameOffering() throws InterruptedException {
         // given
@@ -101,20 +66,18 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
         MemberEntity participant1 = memberFixture.createMember("ever1");
         MemberEntity participant2 = memberFixture.createMember("ever2");
 
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
-
         int executeCount = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(executeCount);
         CountDownLatch countDownLatch = new CountDownLatch(executeCount);
 
-        executorService.execute(() -> {
+        executorService.submit(() -> {
             try {
                 offeringMemberService.participate(request, participant1);
             } finally {
                 countDownLatch.countDown();
             }
         });
-
-        executorService.execute(() -> {
+        executorService.submit(() -> {
             try {
                 offeringMemberService.participate(request, participant2);
             } finally {

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceConcurrencyTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class OfferingMemberServiceTest extends ServiceTest {
+class OfferingMemberServiceConcurrencyTest extends ServiceTest {
 
     @Autowired
     private OfferingMemberService offeringMemberService;
@@ -53,9 +53,9 @@ class OfferingMemberServiceTest extends ServiceTest {
         assertThat(response.participants()).hasSize(executeCount);
     }
 
-    @DisplayName("개선 - 동시에 참여할 경우 중복 참여가 불가능하다.")
+    @DisplayName("개선 - 같은 사용자가 같은 공모에 동시에 참여할 경우 중복 참여가 불가능하다.")
     @Test
-    void should_fail_participateInDuplicate() throws InterruptedException {
+    void should_failParticipate_when_givenSameMemberAndSameOffering() throws InterruptedException {
         // given
         MemberEntity proposer = memberFixture.createMember("ever");
         OfferingEntity offering = offeringFixture.createOffering(proposer);
@@ -67,11 +67,11 @@ class OfferingMemberServiceTest extends ServiceTest {
 
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
-        int executeCount = 100;
+        int executeCount = 5;
         CountDownLatch countDownLatch = new CountDownLatch(executeCount);
 
         for (int i = 0; i < executeCount; i++) {
-            executorService.submit(() -> {
+            executorService.execute(() -> {
                 try {
                     offeringMemberService.participate(request, participant);
                 } finally {
@@ -79,6 +79,48 @@ class OfferingMemberServiceTest extends ServiceTest {
                 }
             });
         }
+
+        countDownLatch.await();
+        executorService.shutdown();
+
+        // then
+        ParticipantResponse response = offeringMemberService.getAllParticipant(offering.getId(), proposer);
+        assertThat(response.participants()).hasSize(1);
+    }
+
+    @DisplayName("개선 - 다른 사용자가 같은 공모에 동시에 참여할 경우 중복 참여가 불가능하다.")
+    @Test
+    void should_failParticipate_when_givenDifferentMemberAndSameOffering() throws InterruptedException {
+        // given
+        MemberEntity proposer = memberFixture.createMember("ever");
+        OfferingEntity offering = offeringFixture.createOffering(proposer, 2);
+        offeringMemberFixture.createProposer(proposer, offering);
+
+        // when
+        ParticipationRequest request = new ParticipationRequest(offering.getId());
+        MemberEntity participant1 = memberFixture.createMember("ever1");
+        MemberEntity participant2 = memberFixture.createMember("ever2");
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        int executeCount = 2;
+        CountDownLatch countDownLatch = new CountDownLatch(executeCount);
+
+        executorService.execute(() -> {
+            try {
+                offeringMemberService.participate(request, participant1);
+            } finally {
+                countDownLatch.countDown();
+            }
+        });
+
+        executorService.execute(() -> {
+            try {
+                offeringMemberService.participate(request, participant2);
+            } finally {
+                countDownLatch.countDown();
+            }
+        });
 
         countDownLatch.await();
         executorService.shutdown();

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
@@ -1,0 +1,53 @@
+package com.zzang.chongdae.offeringmember.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zzang.chongdae.global.service.ServiceTest;
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
+import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponse;
+import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class OfferingMemberServiceTest extends ServiceTest {
+
+    @Autowired
+    private OfferingMemberService offeringMemberService;
+
+    @DisplayName("동시에 참여할 경우 중복 참여가 가능하다.")
+    @Test
+    void should_participateInDuplicate() throws InterruptedException {
+        // given
+        MemberEntity proposer = memberFixture.createMember("ever");
+        OfferingEntity offering = offeringFixture.createOffering(proposer);
+        offeringMemberFixture.createProposer(proposer, offering);
+
+        // when
+        ParticipationRequest request = new ParticipationRequest(offering.getId());
+        MemberEntity participant = memberFixture.createMember("whoever");
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        int executeCount = 2;
+        CountDownLatch countDownLatch = new CountDownLatch(executeCount);
+
+        for (int i = 0; i < executeCount; i++) {
+            executorService.execute(() -> {
+                offeringMemberService.participate(request, participant);
+                countDownLatch.countDown();
+            });
+        }
+
+        countDownLatch.await();
+        executorService.shutdown();
+
+        // then
+        ParticipantResponse response = offeringMemberService.getAllParticipant(offering.getId(), proposer);
+        assertThat(response.participants()).hasSize(executeCount);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
close #664
## ✨ 작업 내용
### 목적
같은 사용자가 같은 공모에 중복 참여 가능한 상황을 해결하기 위함.

### 해결
동시성 이슈 해결 과정은 [제 블로그](https://helenason.tistory.com/21)에 정리해두었어요. 자세한 내용이 궁금하시면 읽어주시면 됩니다! 조회수 늘리기는 덤 ㅎㅎ

요약해서 이야기하자면, 총 네 가지 방법을 떠올렸고 그 중 두 가지 방법 낙관적 잠금과 비관적 쓰기 잠금을 적용할 수 있었어요. 저는 비관적 쓰기 잠금을 걸기로 결정했습니다.

먼저, 참여하기 API는 동시성 이슈 발생률이 낮은 편이기 때문에 속도 테스트를 해보았을 때 낙관적 잠금과 비관적 잠금의 차이가 없었어요. 그래서 성능 측면은 고려하지 않았고, 불필요하게 쿼리가 발생하는 낙관적 잠금의 단점을 피하기 위해 비관적 쓰기 잠금을 선택하도록 하였습니다! 블로그에는 언급하지 않았지만, 낙관적 잠금을 선택할 경우 적절한 예외 처리에 대한 고민이 길어지기도 했어요.
## 📚 기타
