### PR TITLE
refactor: 응답 로그가 쿼리스트링 출력하도록 보완

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/logging/config/LoggingInterceptor.java
+++ b/backend/src/main/java/com/zzang/chongdae/logging/config/LoggingInterceptor.java
@@ -51,7 +51,7 @@ public class LoggingInterceptor implements HandlerInterceptor {
         String identifier = UUID.randomUUID().toString();
         MemberIdentifier memberIdentifier = new MemberIdentifier(request.getCookies());
         String httpMethod = request.getMethod();
-        String uri = request.getRequestURI();
+        String uri = parseUri(request.getRequestURI(), request.getQueryString());
         String requestBody = new String(request.getInputStream().readAllBytes());
 
         CachedHttpServletResponseWrapper cachedResponse = (CachedHttpServletResponseWrapper) response;
@@ -99,5 +99,12 @@ public class LoggingInterceptor implements HandlerInterceptor {
     private boolean isMultipart(HttpServletRequest request) {
         String contentType = request.getContentType();
         return contentType != null && contentType.toLowerCase().startsWith("multipart/");
+    }
+
+    private String parseUri(String requestUri, String queryString) {
+        if (queryString == null) {
+            return requestUri;
+        }
+        return requestUri + "?" + queryString;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #677 

## ✨ 작업 내용
### AS-IS
쿼리스트링이 존재하는 요청에 대해서도 `uri=/offerings`와 같이 쿼리스트링이 표시되지 않아 로그를 확인할 때 매우 불편했음.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/c305eb33-844a-4ca6-9eb8-a00121a26f3b" />

### TO-BE
쿼리스트링이 존재하는 요청에 대해 `uri=/offerings?filter=RECENT&search=title&last-id=10&page-size=10`와 같이 쿼리스트링이 함께 표시되도록 함.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/1aaa5ad7-24b6-4072-8857-60e5fb5962b9" />

## 📚 기타
