### PR TITLE
test: 테스트 환경에서 FCM 서버 대체하던 클래스명 fake -> stub 변경

### DIFF
--- a/backend/src/test/java/com/zzang/chongdae/notification/config/TestNotificationConfig.java
+++ b/backend/src/test/java/com/zzang/chongdae/notification/config/TestNotificationConfig.java
@@ -1,9 +1,9 @@
 package com.zzang.chongdae.notification.config;
 
-import com.zzang.chongdae.notification.service.FakeNotificationSender;
-import com.zzang.chongdae.notification.service.FakeNotificationSubscriber;
 import com.zzang.chongdae.notification.service.NotificationSender;
 import com.zzang.chongdae.notification.service.NotificationSubscriber;
+import com.zzang.chongdae.notification.service.StubNotificationSender;
+import com.zzang.chongdae.notification.service.StubNotificationSubscriber;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -14,14 +14,14 @@ public class TestNotificationConfig {
     @Bean
     @Primary
     public NotificationSender testNotificationSender() {
-        return new FakeNotificationSender();
+        return new StubNotificationSender();
         // return new FcmNotificationSender();
     }
 
     @Bean
     @Primary
     public NotificationSubscriber testNotificationSubscriber() {
-        return new FakeNotificationSubscriber();
+        return new StubNotificationSubscriber();
         // return new FcmNotificationSubscriber();
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/notification/service/StubNotificationSender.java
+++ b/backend/src/test/java/com/zzang/chongdae/notification/service/StubNotificationSender.java
@@ -8,9 +8,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FakeNotificationSender implements NotificationSender {
+public class StubNotificationSender implements NotificationSender {
 
-    private static final Logger log = LoggerFactory.getLogger(FakeNotificationSender.class);
+    private static final Logger log = LoggerFactory.getLogger(StubNotificationSender.class);
 
     @Override
     public String send(Message message) {

--- a/backend/src/test/java/com/zzang/chongdae/notification/service/StubNotificationSubscriber.java
+++ b/backend/src/test/java/com/zzang/chongdae/notification/service/StubNotificationSubscriber.java
@@ -6,9 +6,9 @@ import com.zzang.chongdae.notification.domain.FcmTopic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FakeNotificationSubscriber implements NotificationSubscriber {
+public class StubNotificationSubscriber implements NotificationSubscriber {
 
-    private static final Logger log = LoggerFactory.getLogger(FakeNotificationSubscriber.class);
+    private static final Logger log = LoggerFactory.getLogger(StubNotificationSubscriber.class);
 
     @Override
     public TopicManagementResponse subscribe(MemberEntity member, FcmTopic topic) {


### PR DESCRIPTION
## 📌 관련 이슈
close #685 

## ✨ 작업 내용
테스트 환경에서 FCM 서버 대체하던 클래스명 fake -> stub 변경

## 📚 기타
