### PR TITLE
fix: 테스트 구동 시 인증 설정 관련 빈 주입 오류 해결

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/auth/config/AuthClientConfig.java
+++ b/backend/src/main/java/com/zzang/chongdae/auth/config/AuthClientConfig.java
@@ -1,7 +1,8 @@
 package com.zzang.chongdae.auth.config;
 
 import com.zzang.chongdae.auth.service.AuthClient;
-import com.zzang.chongdae.auth.service.DevAuthClient;
+import com.zzang.chongdae.auth.service.client.DevAuthClient;
+import com.zzang.chongdae.auth.service.client.ProdAuthClient;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +27,7 @@ public class AuthClientConfig {
     @Bean
     @Profile("prod")
     public AuthClient prodAuthClient() {
-        return new AuthClient(createRestClient());
+        return new ProdAuthClient(createRestClient());
     }
 
     @Bean

--- a/backend/src/main/java/com/zzang/chongdae/auth/service/AuthClient.java
+++ b/backend/src/main/java/com/zzang/chongdae/auth/service/AuthClient.java
@@ -1,31 +1,6 @@
 package com.zzang.chongdae.auth.service;
 
-import com.zzang.chongdae.auth.exception.KakaoLoginExceptionHandler;
-import com.zzang.chongdae.auth.service.dto.KakaoLoginResponseDto;
-import com.zzang.chongdae.member.domain.AuthProvider;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.web.client.RestClient;
+public interface AuthClient {
 
-@RequiredArgsConstructor
-public class AuthClient {
-
-    private static final String BEARER_HEADER_FORMAT = "Bearer %s";
-    private static final String GET_KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
-
-    private final RestClient restClient;
-
-    public String getKakaoUserInfo(String accessToken) {
-        KakaoLoginResponseDto responseDto = restClient.get()
-                .uri(GET_KAKAO_USER_INFO_URI)
-                .header(HttpHeaders.AUTHORIZATION, createAuthorization(accessToken))
-                .retrieve()
-                .onStatus(new KakaoLoginExceptionHandler())
-                .body(KakaoLoginResponseDto.class);
-        return AuthProvider.KAKAO.buildLoginId(responseDto.id().toString()); // TODO: NPE 처리 고려하기
-    }
-
-    private String createAuthorization(String accessToken) {
-        return BEARER_HEADER_FORMAT.formatted(accessToken);
-    }
+    String getUserInfo(String accessToken);
 }

--- a/backend/src/main/java/com/zzang/chongdae/auth/service/AuthService.java
+++ b/backend/src/main/java/com/zzang/chongdae/auth/service/AuthService.java
@@ -34,7 +34,7 @@ public class AuthService {
     @WriterDatabase
     @Transactional
     public AuthInfoDto kakaoLogin(KakaoLoginRequest request) {
-        String loginId = authClient.getKakaoUserInfo(request.accessToken());
+        String loginId = authClient.getUserInfo(request.accessToken());
         AuthProvider provider = AuthProvider.KAKAO;
         MemberEntity member = memberRepository.findByLoginId(loginId)
                 .orElseGet(() -> signup(provider, loginId, request.fcmToken()));

--- a/backend/src/main/java/com/zzang/chongdae/auth/service/client/DevAuthClient.java
+++ b/backend/src/main/java/com/zzang/chongdae/auth/service/client/DevAuthClient.java
@@ -1,16 +1,16 @@
-package com.zzang.chongdae.auth.service;
+package com.zzang.chongdae.auth.service.client;
 
 import com.zzang.chongdae.global.exception.MarketException;
 import org.springframework.web.client.RestClient;
 
-public class DevAuthClient extends AuthClient {
+public class DevAuthClient extends ProdAuthClient {
 
     public DevAuthClient(RestClient restClient) {
         super(restClient);
     }
 
     @Override
-    public String getKakaoUserInfo(String accessToken) {
+    protected String getKakaoUserInfo(String accessToken) {
         try {
             return super.getKakaoUserInfo(accessToken);
         } catch (MarketException e) {

--- a/backend/src/main/java/com/zzang/chongdae/auth/service/client/ProdAuthClient.java
+++ b/backend/src/main/java/com/zzang/chongdae/auth/service/client/ProdAuthClient.java
@@ -1,0 +1,37 @@
+package com.zzang.chongdae.auth.service.client;
+
+import com.zzang.chongdae.auth.exception.KakaoLoginExceptionHandler;
+import com.zzang.chongdae.auth.service.AuthClient;
+import com.zzang.chongdae.auth.service.dto.KakaoLoginResponseDto;
+import com.zzang.chongdae.member.domain.AuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestClient;
+
+@RequiredArgsConstructor
+public class ProdAuthClient implements AuthClient {
+
+    private static final String BEARER_HEADER_FORMAT = "Bearer %s";
+    private static final String GET_KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestClient restClient;
+
+    @Override
+    public String getUserInfo(String accessToken) {
+        return getKakaoUserInfo(accessToken);
+    }
+
+    protected String getKakaoUserInfo(String accessToken) {
+        KakaoLoginResponseDto responseDto = restClient.get()
+                .uri(GET_KAKAO_USER_INFO_URI)
+                .header(HttpHeaders.AUTHORIZATION, createAuthorization(accessToken))
+                .retrieve()
+                .onStatus(new KakaoLoginExceptionHandler())
+                .body(KakaoLoginResponseDto.class);
+        return AuthProvider.KAKAO.buildLoginId(responseDto.id().toString()); // TODO: NPE 처리 고려하기
+    }
+
+    private String createAuthorization(String accessToken) {
+        return BEARER_HEADER_FORMAT.formatted(accessToken);
+    }
+}

--- a/backend/src/test/java/com/zzang/chongdae/auth/config/TestAuthClientConfig.java
+++ b/backend/src/test/java/com/zzang/chongdae/auth/config/TestAuthClientConfig.java
@@ -1,0 +1,15 @@
+package com.zzang.chongdae.auth.config;
+
+import com.zzang.chongdae.auth.service.AuthClient;
+import com.zzang.chongdae.auth.service.StubAuthClient;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestAuthClientConfig {
+
+    @Bean
+    AuthClient testAuthConfig() {
+        return new StubAuthClient();
+    }
+}

--- a/backend/src/test/java/com/zzang/chongdae/auth/integration/AuthIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/auth/integration/AuthIntegrationTest.java
@@ -69,7 +69,7 @@ class AuthIntegrationTest extends IntegrationTest {
         @BeforeEach
         void setUp() {
             member = memberFixture.createMember("dora");
-            BDDMockito.given(authClient.getKakaoUserInfo(any()))
+            BDDMockito.given(authClient.getUserInfo(any()))
                     .willReturn(member.getLoginId());
         }
 

--- a/backend/src/test/java/com/zzang/chongdae/auth/service/StubAuthClient.java
+++ b/backend/src/test/java/com/zzang/chongdae/auth/service/StubAuthClient.java
@@ -1,0 +1,9 @@
+package com.zzang.chongdae.auth.service;
+
+public class StubAuthClient implements AuthClient {
+
+    @Override
+    public String getUserInfo(String accessToken) {
+        return "stubUserInfo";
+    }
+}

--- a/backend/src/test/java/com/zzang/chongdae/global/config/TestConfig.java
+++ b/backend/src/test/java/com/zzang/chongdae/global/config/TestConfig.java
@@ -1,5 +1,6 @@
 package com.zzang.chongdae.global.config;
 
+import com.zzang.chongdae.auth.config.TestAuthClientConfig;
 import com.zzang.chongdae.member.config.TestNicknameWordPickerConfig;
 import com.zzang.chongdae.notification.config.TestNotificationConfig;
 import com.zzang.chongdae.offering.config.TestCrawlerConfig;
@@ -11,7 +12,8 @@ import org.springframework.context.annotation.Import;
         TestNicknameWordPickerConfig.class,
         TestClockConfig.class,
         TestNotificationConfig.class,
-        TestStorageConfig.class})
+        TestStorageConfig.class,
+        TestAuthClientConfig.class})
 @TestConfiguration
 public class TestConfig {
 }

--- a/backend/src/test/java/com/zzang/chongdae/member/service/NicknameGeneratorTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/member/service/NicknameGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.zzang.chongdae.member.service;
 
+import com.zzang.chongdae.auth.config.TestAuthClientConfig;
 import com.zzang.chongdae.member.config.TestNicknameWordPickerConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -10,7 +11,8 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = {TestNicknameWordPickerConfig.class})
+@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = {TestNicknameWordPickerConfig.class,
+        TestAuthClientConfig.class})
 public class NicknameGeneratorTest {
 
     @Autowired


### PR DESCRIPTION
## 📌 관련 이슈
close #693 
## ✨ 작업 내용
- 테스트 구동 시 AuthClient 빈주입이 안됬던 현상을 해결합니다.
- 테스트 환경과 프로덕션 환경을 분리하기 위해 Stub객체를 활용하는 선택을 했습니다. 외부 API를 호출하는 실수를 방지하기 위함입니다
 
## 📚 기타
테스트환경과 분리하기 위해 코드를 작성하다보니 기존 AuthClient를  인터페이스로 변경했고 TestConfiguration를 별도로 작성했습니다.
솔직히 AuthClientConfiguration에 `test` 프로파일 한 줄로 작성한 것 보다 품이 많이 들어간 것 같은데 여러분들의 의견이 필요합니다.

**요약 : `test` 프로파일 추가 vs 지금 PR처럼 프로덕션과 테스트환경 분리**