### PR TITLE
refactor: N+1 문제 해결을 위한 로딩 전략 및 쿼리 변경

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/repository/CommentRepository.java
@@ -5,10 +5,18 @@ import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 
-    List<CommentEntity> findAllByOfferingOrderByCreatedAt(OfferingEntity offering);
+    @Query("""
+            SELECT c
+            FROM CommentEntity c
+                JOIN FETCH c.member
+            WHERE c.offering = :offering
+            ORDER BY c.createdAt
+            """)
+    List<CommentEntity> findAllWithMemberByOfferingOrderByCreatedAt(OfferingEntity offering);
 
     Optional<CommentEntity> findTopByOfferingIdOrderByCreatedAtDesc(Long offeringId);
 }

--- a/backend/src/main/java/com/zzang/chongdae/comment/repository/entity/CommentEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/repository/entity/CommentEntity.java
@@ -31,7 +31,7 @@ public class CommentEntity extends BaseTimeEntity {
     private Long id;
 
     @NotNull
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private MemberEntity member;
 
     @NotNull

--- a/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
@@ -50,7 +50,7 @@ public class CommentService {
         CommentEntity comment = new CommentEntity(member, offering, request.content());
         CommentEntity savedComment = commentRepository.save(comment);
 
-        List<OfferingMemberEntity> offeringMembers = offeringMemberRepository.findAllByOffering(offering);
+        List<OfferingMemberEntity> offeringMembers = offeringMemberRepository.findAllWithMemberByOffering(offering);
         eventPublisher.publishEvent(new SaveCommentEvent(this, savedComment, offeringMembers));
 
         return savedComment.getId();

--- a/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
@@ -124,7 +124,7 @@ public class CommentService {
         OfferingEntity offering = offeringRepository.findByIdWithDeleted(offeringId)
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateIsJoined(member, offering);
-        List<CommentEntity> comments = commentRepository.findAllByOfferingOrderByCreatedAt(offering);
+        List<CommentEntity> comments = commentRepository.findAllWithMemberByOfferingOrderByCreatedAt(offering);
         List<CommentAllResponseItem> responseItems = comments.stream()
                 .map(comment -> new CommentAllResponseItem(comment, member))
                 .toList();

--- a/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
@@ -48,12 +48,12 @@ public class CommentService {
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateIsJoined(member, offering);
         CommentEntity comment = new CommentEntity(member, offering, request.content());
-        CommentEntity savedComment = commentRepository.save(comment);
+        CommentEntity saved = commentRepository.save(comment);
 
         List<OfferingMemberEntity> offeringMembers = offeringMemberRepository.findAllWithMemberByOffering(offering);
-        eventPublisher.publishEvent(new SaveCommentEvent(this, savedComment, offeringMembers));
+        eventPublisher.publishEvent(new SaveCommentEvent(this, saved, offeringMembers));
 
-        return savedComment.getId();
+        return saved.getId();
     }
 
     private void validateIsJoined(MemberEntity member, OfferingEntity offering) {

--- a/backend/src/main/java/com/zzang/chongdae/event/domain/CancelParticipateEvent.java
+++ b/backend/src/main/java/com/zzang/chongdae/event/domain/CancelParticipateEvent.java
@@ -1,5 +1,7 @@
 package com.zzang.chongdae.event.domain;
 
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.notification.domain.FcmToken;
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
@@ -8,9 +10,17 @@ import org.springframework.context.ApplicationEvent;
 public class CancelParticipateEvent extends ApplicationEvent {
 
     private final OfferingMemberEntity offeringMember;
+    private final MemberEntity participant;
+    private final FcmToken token;
 
     public CancelParticipateEvent(Object source, OfferingMemberEntity offeringMember) {
         super(source);
         this.offeringMember = offeringMember;
+        this.participant = offeringMember.getMember();
+        this.token = createFcmToken();
+    }
+
+    private FcmToken createFcmToken() {
+        return new FcmToken(offeringMember.getMember());
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/event/domain/ParticipateEvent.java
+++ b/backend/src/main/java/com/zzang/chongdae/event/domain/ParticipateEvent.java
@@ -1,5 +1,6 @@
 package com.zzang.chongdae.event.domain;
 
+import com.zzang.chongdae.notification.domain.FcmToken;
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
@@ -8,9 +9,15 @@ import org.springframework.context.ApplicationEvent;
 public class ParticipateEvent extends ApplicationEvent {
 
     private final OfferingMemberEntity offeringMember;
+    private final FcmToken token;
 
     public ParticipateEvent(Object source, OfferingMemberEntity offeringMember) {
         super(source);
         this.offeringMember = offeringMember;
+        this.token = createFcmToken();
+    }
+
+    private FcmToken createFcmToken() {
+        return new FcmToken(offeringMember.getOffering().getMember());
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/event/domain/SaveCommentEvent.java
+++ b/backend/src/main/java/com/zzang/chongdae/event/domain/SaveCommentEvent.java
@@ -1,6 +1,8 @@
 package com.zzang.chongdae.event.domain;
 
 import com.zzang.chongdae.comment.repository.entity.CommentEntity;
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.notification.domain.FcmTokens;
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
 import java.util.List;
 import lombok.Getter;
@@ -10,11 +12,19 @@ import org.springframework.context.ApplicationEvent;
 public class SaveCommentEvent extends ApplicationEvent {
 
     private final CommentEntity comment;
-    private final List<OfferingMemberEntity> offeringMembers;
+    private final FcmTokens tokens;
 
     public SaveCommentEvent(Object source, CommentEntity comment, List<OfferingMemberEntity> offeringMembers) {
         super(source);
         this.comment = comment;
-        this.offeringMembers = offeringMembers;
+        this.tokens = createFcmTokens(comment.getMember(), offeringMembers);
+    }
+
+    private FcmTokens createFcmTokens(MemberEntity writer, List<OfferingMemberEntity> offeringMembers) {
+        List<MemberEntity> membersNotWriter = offeringMembers.stream()
+                .map(OfferingMemberEntity::getMember)
+                .filter(member -> !member.isSame(writer))
+                .toList();
+        return FcmTokens.from(membersNotWriter);
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/event/service/FcmEventListener.java
+++ b/backend/src/main/java/com/zzang/chongdae/event/service/FcmEventListener.java
@@ -25,13 +25,13 @@ public class FcmEventListener {
     @TransactionalEventListener(phase = AFTER_COMMIT)
     @Async
     public void handleParticipateEvent(ParticipateEvent event) {
-        notificationService.participate(event.getOfferingMember());
+        notificationService.participate(event.getOfferingMember(), event.getToken());
     }
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     @Async
     public void handleCancelParticipateEvent(CancelParticipateEvent event) {
-        notificationService.cancelParticipation(event.getOfferingMember());
+        notificationService.cancelParticipation(event.getOfferingMember(), event.getParticipant(), event.getToken());
     }
 
     @EventListener

--- a/backend/src/main/java/com/zzang/chongdae/event/service/FcmEventListener.java
+++ b/backend/src/main/java/com/zzang/chongdae/event/service/FcmEventListener.java
@@ -49,7 +49,7 @@ public class FcmEventListener {
     @EventListener
     @Async
     public void handleSaveCommentEvent(SaveCommentEvent event) {
-        notificationService.saveComment(event.getComment(), event.getOfferingMembers());
+        notificationService.saveComment(event.getComment(), event.getTokens());
     }
 
     @TransactionalEventListener(phase = AFTER_COMMIT)

--- a/backend/src/main/java/com/zzang/chongdae/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/zzang/chongdae/notification/service/FcmNotificationService.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.MulticastMessage;
 import com.zzang.chongdae.comment.repository.entity.CommentEntity;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.notification.domain.FcmToken;
+import com.zzang.chongdae.notification.domain.FcmTokens;
 import com.zzang.chongdae.notification.domain.FcmTopic;
 import com.zzang.chongdae.notification.service.message.CommentMessageManager;
 import com.zzang.chongdae.notification.service.message.OfferingMessageManager;
@@ -13,7 +14,6 @@ import com.zzang.chongdae.notification.service.message.ParticipationMessageManag
 import com.zzang.chongdae.notification.service.message.RoomStatusMessageManager;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
-import java.util.List;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -61,11 +61,11 @@ public class FcmNotificationService {
     }
 
     @Nullable
-    public BatchResponse saveComment(CommentEntity comment, List<OfferingMemberEntity> offeringMembers) {
-        MulticastMessage message = commentMessageManager.messageWhenSaveComment(comment, offeringMembers);
-        if (message == null) {
+    public BatchResponse saveComment(CommentEntity comment, FcmTokens tokens) {
+        if (tokens.isEmpty()) {
             return null;
         }
+        MulticastMessage message = commentMessageManager.messageWhenSaveComment(comment, tokens);
         return notificationSender.send(message);
     }
 

--- a/backend/src/main/java/com/zzang/chongdae/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/zzang/chongdae/notification/service/FcmNotificationService.java
@@ -61,8 +61,7 @@ public class FcmNotificationService {
     }
 
     @Nullable
-    public BatchResponse saveComment(CommentEntity comment,
-                                     List<OfferingMemberEntity> offeringMembers) { // todo: 참여자 도메인 추출
+    public BatchResponse saveComment(CommentEntity comment, List<OfferingMemberEntity> offeringMembers) {
         MulticastMessage message = commentMessageManager.messageWhenSaveComment(comment, offeringMembers);
         if (message == null) {
             return null;

--- a/backend/src/main/java/com/zzang/chongdae/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/zzang/chongdae/notification/service/FcmNotificationService.java
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MulticastMessage;
 import com.zzang.chongdae.comment.repository.entity.CommentEntity;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.notification.domain.FcmToken;
 import com.zzang.chongdae.notification.domain.FcmTopic;
 import com.zzang.chongdae.notification.service.message.CommentMessageManager;
 import com.zzang.chongdae.notification.service.message.OfferingMessageManager;
@@ -28,17 +29,17 @@ public class FcmNotificationService {
     private final ParticipationMessageManager participationMessageManager;
     private final RoomStatusMessageManager roomStatusMessageManager; // TODO: 의존성 리팩터링
 
-    public void participate(OfferingMemberEntity offeringMember) {
+    public void participate(OfferingMemberEntity offeringMember, FcmToken token) {
         FcmTopic topic = FcmTopic.participantTopic(offeringMember.getOffering());
         notificationSubscriber.subscribe(offeringMember.getMember(), topic);
-        Message message = participationMessageManager.messageWhenParticipate(offeringMember);
+        Message message = participationMessageManager.messageWhenParticipate(offeringMember, token);
         notificationSender.send(message);
     }
 
-    public void cancelParticipation(OfferingMemberEntity offeringMember) {
+    public void cancelParticipation(OfferingMemberEntity offeringMember, MemberEntity participant, FcmToken token) {
         FcmTopic topic = FcmTopic.participantTopic(offeringMember.getOffering());
         notificationSubscriber.unsubscribe(offeringMember.getMember(), topic);
-        Message message = participationMessageManager.messageWhenCancelParticipate(offeringMember);
+        Message message = participationMessageManager.messageWhenCancelParticipate(offeringMember, participant, token);
         notificationSender.send(message);
     }
 

--- a/backend/src/main/java/com/zzang/chongdae/notification/service/message/CommentMessageManager.java
+++ b/backend/src/main/java/com/zzang/chongdae/notification/service/message/CommentMessageManager.java
@@ -22,7 +22,7 @@ public class CommentMessageManager {
 
     @Nullable
     public MulticastMessage messageWhenSaveComment(CommentEntity comment, List<OfferingMemberEntity> offeringMembers) {
-        FcmTokens tokens = FcmTokens.from(membersNotWriter(comment.getMember(), offeringMembers));
+        FcmTokens tokens = createFcmTokens(comment.getMember(), offeringMembers);
         if (tokens.isEmpty()) {
             return null;
         }
@@ -34,10 +34,11 @@ public class CommentMessageManager {
         return messageCreator.createMessages(tokens, data);
     }
 
-    private List<MemberEntity> membersNotWriter(MemberEntity writer, List<OfferingMemberEntity> offeringMembers) {
-        return offeringMembers.stream()
+    private FcmTokens createFcmTokens(MemberEntity writer, List<OfferingMemberEntity> offeringMembers) {
+        List<MemberEntity> membersNotWriter = offeringMembers.stream()
                 .map(OfferingMemberEntity::getMember)
                 .filter(member -> !member.isSame(writer))
                 .toList();
+        return FcmTokens.from(membersNotWriter);
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/notification/service/message/CommentMessageManager.java
+++ b/backend/src/main/java/com/zzang/chongdae/notification/service/message/CommentMessageManager.java
@@ -2,12 +2,8 @@ package com.zzang.chongdae.notification.service.message;
 
 import com.google.firebase.messaging.MulticastMessage;
 import com.zzang.chongdae.comment.repository.entity.CommentEntity;
-import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.notification.domain.FcmData;
 import com.zzang.chongdae.notification.domain.FcmTokens;
-import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
-import java.util.List;
-import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -20,25 +16,12 @@ public class CommentMessageManager {
 
     private final FcmMessageCreator messageCreator;
 
-    @Nullable
-    public MulticastMessage messageWhenSaveComment(CommentEntity comment, List<OfferingMemberEntity> offeringMembers) {
-        FcmTokens tokens = createFcmTokens(comment.getMember(), offeringMembers);
-        if (tokens.isEmpty()) {
-            return null;
-        }
+    public MulticastMessage messageWhenSaveComment(CommentEntity comment, FcmTokens tokens) {
         FcmData data = new FcmData();
         data.addData("title", comment.getOffering().getTitle());
         data.addData("body", MESSAGE_BODY_FORMAT.formatted(comment.getMember().getNickname(), comment.getContent()));
         data.addData("offering_id", comment.getOffering().getId());
         data.addData("type", MESSAGE_TYPE);
         return messageCreator.createMessages(tokens, data);
-    }
-
-    private FcmTokens createFcmTokens(MemberEntity writer, List<OfferingMemberEntity> offeringMembers) {
-        List<MemberEntity> membersNotWriter = offeringMembers.stream()
-                .map(OfferingMemberEntity::getMember)
-                .filter(member -> !member.isSame(writer))
-                .toList();
-        return FcmTokens.from(membersNotWriter);
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/notification/service/message/ParticipationMessageManager.java
+++ b/backend/src/main/java/com/zzang/chongdae/notification/service/message/ParticipationMessageManager.java
@@ -19,12 +19,9 @@ public class ParticipationMessageManager {
 
     private final FcmMessageCreator messageCreator;
 
-    public Message messageWhenParticipate(OfferingMemberEntity offeringMember) {
+    public Message messageWhenParticipate(OfferingMemberEntity offeringMember, FcmToken token) {
         OfferingEntity offering = offeringMember.getOffering();
-        MemberEntity proposer = offering.getMember();
         MemberEntity participant = offeringMember.getMember();
-
-        FcmToken token = new FcmToken(proposer);
         FcmData data = new FcmData();
         data.addData("title", offering.getTitle());
         data.addData("body", MESSAGE_BODY_FORMAT_PARTICIPATE.formatted(participant.getNickname()));
@@ -33,12 +30,9 @@ public class ParticipationMessageManager {
         return messageCreator.createMessage(token, data);
     }
 
-    public Message messageWhenCancelParticipate(OfferingMemberEntity offeringMember) {
+    public Message messageWhenCancelParticipate(OfferingMemberEntity offeringMember, MemberEntity participant,
+                                                FcmToken token) {
         OfferingEntity offering = offeringMember.getOffering();
-        MemberEntity proposer = offering.getMember();
-        MemberEntity participant = offeringMember.getMember();
-
-        FcmToken token = new FcmToken(proposer);
         FcmData data = new FcmData();
         data.addData("title", offering.getTitle());
         data.addData("body", MESSAGE_BODY_FORMAT_CANCEL.formatted(participant.getNickname()));

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/repository/OfferingMemberRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/repository/OfferingMemberRepository.java
@@ -12,13 +12,19 @@ public interface OfferingMemberRepository extends JpaRepository<OfferingMemberEn
 
     Boolean existsByOfferingAndMember(OfferingEntity offering, MemberEntity member);
 
-    List<OfferingMemberEntity> findAllByOffering(OfferingEntity offering);
+    @Query("""
+            SELECT om
+            FROM OfferingMemberEntity om
+                JOIN FETCH om.member
+            WHERE om.offering = :offering
+            """)
+    List<OfferingMemberEntity> findAllWithMemberByOffering(OfferingEntity offering);
 
     Optional<OfferingMemberEntity> findByOfferingAndMember(OfferingEntity offering, MemberEntity member);
 
     Optional<OfferingMemberEntity> findByOfferingIdAndMember(Long offeringId, MemberEntity member);
 
-    @Query(value = """
+    @Query("""
             SELECT om.offering.id
             FROM OfferingMemberEntity om
             WHERE om.member.id = :memberId

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/repository/entity/OfferingMemberEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/repository/entity/OfferingMemberEntity.java
@@ -33,7 +33,7 @@ public class OfferingMemberEntity extends BaseTimeEntity {
     private Long id;
 
     @NotNull
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private MemberEntity member;
 
     @NotNull

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -14,11 +14,8 @@ import com.zzang.chongdae.offeringmember.domain.OfferingMembers;
 import com.zzang.chongdae.offeringmember.exception.OfferingMemberErrorCode;
 import com.zzang.chongdae.offeringmember.repository.OfferingMemberRepository;
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
-import com.zzang.chongdae.offeringmember.service.dto.ParticipantCountResponseItem;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponse;
-import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponseItem;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
-import com.zzang.chongdae.offeringmember.service.dto.ProposerResponseItem;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -107,17 +104,7 @@ public class OfferingMemberService {
 
         List<OfferingMemberEntity> offeringMembers = offeringMemberRepository.findAllWithMemberByOffering(offering);
         OfferingMembers members = new OfferingMembers(offeringMembers);
-        MemberEntity proposer = members.getProposer();
-        List<MemberEntity> participants = members.getParticipants();
-
-        ProposerResponseItem proposerResponseItem = new ProposerResponseItem(proposer);
-        List<ParticipantResponseItem> participantsResponseItem = participants.stream()
-                .map(ParticipantResponseItem::new)
-                .toList();
-        ParticipantCountResponseItem countResponseItem = new ParticipantCountResponseItem(offering);
-        Integer estimatedPrice = offering.toOfferingPrice().calculateDividedPrice();
-        return new ParticipantResponse(
-                proposerResponseItem, participantsResponseItem, countResponseItem, estimatedPrice);
+        return ParticipantResponse.from(offering, members);
     }
 
     private void validateParticipants(OfferingEntity offering, MemberEntity member) {

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -105,7 +105,7 @@ public class OfferingMemberService {
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateParticipants(offering, member);
 
-        List<OfferingMemberEntity> offeringMembers = offeringMemberRepository.findAllByOffering(offering);
+        List<OfferingMemberEntity> offeringMembers = offeringMemberRepository.findAllWithMemberByOffering(offering);
         OfferingMembers members = new OfferingMembers(offeringMembers);
         MemberEntity proposer = members.getProposer();
         List<MemberEntity> participants = members.getParticipants();

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponse.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponse.java
@@ -1,5 +1,8 @@
 package com.zzang.chongdae.offeringmember.service.dto;
 
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
+import com.zzang.chongdae.offeringmember.domain.OfferingMembers;
 import java.util.List;
 
 public record ParticipantResponse(ProposerResponseItem proposer,
@@ -7,4 +10,16 @@ public record ParticipantResponse(ProposerResponseItem proposer,
                                   ParticipantCountResponseItem count,
                                   Integer price
 ) {
+
+    public static ParticipantResponse from(OfferingEntity offering, OfferingMembers offeringMembers) {
+        MemberEntity proposer = offeringMembers.getProposer();
+        List<MemberEntity> participants = offeringMembers.getParticipants();
+        ProposerResponseItem proposerResponse = new ProposerResponseItem(proposer);
+        List<ParticipantResponseItem> participantsResponse = participants.stream()
+                .map(ParticipantResponseItem::new)
+                .toList();
+        ParticipantCountResponseItem countResponse = new ParticipantCountResponseItem(offering);
+        Integer priceResponse = offering.toOfferingPrice().calculateDividedPrice();
+        return new ParticipantResponse(proposerResponse, participantsResponse, countResponse, priceResponse);
+    }
 }

--- a/backend/src/test/java/com/zzang/chongdae/comment/integration/CommentIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/comment/integration/CommentIntegrationTest.java
@@ -362,15 +362,27 @@ public class CommentIntegrationTest extends IntegrationTest {
                 .responseFields(failResponseDescriptors)
                 .responseSchema(schema("CommentAllFailResponse"))
                 .build();
-        MemberEntity member;
+        MemberEntity member1, member2, member3, member4, member5;
         OfferingEntity offering;
 
         @BeforeEach
         void setUp() {
-            member = memberFixture.createMember("dora");
-            offering = offeringFixture.createOffering(member);
-            offeringMemberFixture.createProposer(member, offering);
-            commentFixture.createComment(member, offering);
+            member1 = memberFixture.createMember("dora");
+            member2 = memberFixture.createMember("ever");
+            member3 = memberFixture.createMember("poke");
+            member4 = memberFixture.createMember("mason");
+            member5 = memberFixture.createMember("whatever");
+            offering = offeringFixture.createOffering(member1);
+            offeringMemberFixture.createProposer(member1, offering);
+            offeringMemberFixture.createParticipant(member2, offering);
+            offeringMemberFixture.createParticipant(member3, offering);
+            offeringMemberFixture.createParticipant(member4, offering);
+            offeringMemberFixture.createParticipant(member5, offering);
+            commentFixture.createComment(member1, offering);
+            commentFixture.createComment(member2, offering);
+            commentFixture.createComment(member3, offering);
+            commentFixture.createComment(member4, offering);
+            commentFixture.createComment(member5, offering);
         }
 
         @DisplayName("댓글 목록을 조회할 수 있다")
@@ -378,7 +390,7 @@ public class CommentIntegrationTest extends IntegrationTest {
         void should_responseAllComment_when_givenOfferingIdAndMemberId() {
             RestAssured.given(spec).log().all()
                     .filter(document("get-all-comment-success", resource(successSnippets)))
-                    .cookies(cookieProvider.createCookiesWithMember(member))
+                    .cookies(cookieProvider.createCookiesWithMember(member1))
                     .queryParam("offering-id", offering.getId())
                     .when().get("/comments/messages")
                     .then().log().all()
@@ -390,7 +402,7 @@ public class CommentIntegrationTest extends IntegrationTest {
         void should_throwException_when_invalidOffering() {
             RestAssured.given(spec).log().all()
                     .filter(document("get-all-comment-fail-invalid-offering", resource(failSnippets)))
-                    .cookies(cookieProvider.createCookiesWithMember(member))
+                    .cookies(cookieProvider.createCookiesWithMember(member1))
                     .queryParam("offering-id", offering.getId() + 100)
                     .when().get("/comments/messages")
                     .then().log().all()


### PR DESCRIPTION
## 📌 관련 이슈
close #687 
## ✨ 작업 내용

### 1. N+1 문제 해결을 위해 로딩 전략 변경 및 fetch join 적용
N+1 문제를 해결하기 위해 아래 두가지를 적용하였습니다.
- 로딩 전략 EAGER → LAZY
- 기존 쿼리 → fetch join

자세한 과정은 [블로그](https://helenason.tistory.com/25)를 참고해주세요. N+1 문제가 발생했던 기능은 참여자 목록 조회와 채팅방 목록 조회였고, 두 기능 모두에서 해결 완료하였습니다.

### 2. 비동기 스레드에서 발생한 LazyInitializationException 해결

추가로, N+1 문제를 해결하는 과정에서 다른 문제도 발견했습니다. 알림 로직에서 LazyInitializationException이 발생한 문제인데요. 비동기 스레드에서 발생한 예외를 로깅만 하고 따로 처리하지 않고 있기 때문에 이제서야 로그를 통해 발견하게 되었습니다.

트랜잭션이 닫힌 상태에서 지연로딩 프록시 객체에 접근했기 때문에 발생한 문제인데요, 트랜잭션이 닫히기 전 미리 해당 정보를 조회하여 비동기 스레드에 전달하도록 하였습니다.

관련하여 자세한 내용은 역시 [블로그](https://helenason.tistory.com/26)를 통해 확인해주시면 감사하겠습니다 :)


## 📚 기타
