### PR TITLE
feat: 닉네임 변경 기능 구현

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/zzang/chongdae/global/exception/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -57,8 +58,8 @@ public class GlobalExceptionHandler {
                 .body(errorMessage);
     }
 
-    @ExceptionHandler
-    public ResponseEntity<ErrorMessage> handle(DataIntegrityViolationException e) {
+    @ExceptionHandler({DataIntegrityViolationException.class, ObjectOptimisticLockingFailureException.class})
+    public ResponseEntity<ErrorMessage> handle(Exception e) {
         ErrorMessage errorMessage = new ErrorMessage("잠시후 다시 요청해주세요.");
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorMessage);
     }

--- a/backend/src/main/java/com/zzang/chongdae/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/zzang/chongdae/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,8 @@ import java.io.StringWriter;
 import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -53,6 +55,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(DataIntegrityViolationException e) {
+        ErrorMessage errorMessage = new ErrorMessage("잠시후 다시 요청해주세요.");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorMessage);
     }
 
     @ExceptionHandler

--- a/backend/src/main/java/com/zzang/chongdae/member/controller/MemberController.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package com.zzang.chongdae.member.controller;
+
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.member.service.MemberService;
+import com.zzang.chongdae.member.service.dto.NicknameRequest;
+import com.zzang.chongdae.member.service.dto.NicknameResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RequiredArgsConstructor
+@Controller
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PatchMapping("/member")
+    ResponseEntity<NicknameResponse> changeNickName(
+            @RequestBody @Valid NicknameRequest request,
+            MemberEntity member) {
+        NicknameResponse nicknameResponse = memberService.changeNickname(member, request);
+        return ResponseEntity.ok(nicknameResponse);
+    }
+}

--- a/backend/src/main/java/com/zzang/chongdae/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/exception/MemberErrorCode.java
@@ -16,7 +16,7 @@ public enum MemberErrorCode implements ErrorResponse {
 
     NOT_FOUND(BAD_REQUEST, "해당 사용자가 존재하지 않습니다."),
     MAX_TRY_EXCEEDED(INTERNAL_SERVER_ERROR, "닉네임 생성에 실패했습니다."),
-    NICK_NAME_READ_FAIL(INTERNAL_SERVER_ERROR, "닉네임 데이터 읽기를 실패했습닏."),
+    NICK_NAME_READ_FAIL(INTERNAL_SERVER_ERROR, "닉네임 데이터 읽기를 실패했습니다."),
     NICK_NAME_ALREADY_EXIST(CONFLICT, "이미 사용중인 닉네임입니다.");
 
     private final HttpStatus status;

--- a/backend/src/main/java/com/zzang/chongdae/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/exception/MemberErrorCode.java
@@ -1,6 +1,7 @@
 package com.zzang.chongdae.member.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import com.zzang.chongdae.global.exception.ErrorMessage;
@@ -15,7 +16,8 @@ public enum MemberErrorCode implements ErrorResponse {
 
     NOT_FOUND(BAD_REQUEST, "해당 사용자가 존재하지 않습니다."),
     MAX_TRY_EXCEEDED(INTERNAL_SERVER_ERROR, "닉네임 생성에 실패했습니다."),
-    NICK_NAME_READ_FAIL(INTERNAL_SERVER_ERROR, "닉네임 데이터 읽기를 실패했습닏.");
+    NICK_NAME_READ_FAIL(INTERNAL_SERVER_ERROR, "닉네임 데이터 읽기를 실패했습닏."),
+    NICK_NAME_ALREADY_EXIST(CONFLICT, "이미 사용중인 닉네임입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/zzang/chongdae/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/repository/MemberRepository.java
@@ -20,6 +20,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     boolean existsByIdAndFcmToken(Long id, String fcmToken);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT m FROM MemberEntity m WHERE m.id = 1 or m.nickname = :nickname")
-    Optional<MemberEntity> findByNicknameWithLock(String nickname);
+    @Query("SELECT m FROM MemberEntity m WHERE m.id = :id")
+    Optional<MemberEntity> findByIdWithLock(Long id);
 }

--- a/backend/src/main/java/com/zzang/chongdae/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/repository/MemberRepository.java
@@ -1,11 +1,8 @@
 package com.zzang.chongdae.member.repository;
 
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
-import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
@@ -18,8 +15,4 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     Optional<MemberEntity> findByLoginId(String loginId);
 
     boolean existsByIdAndFcmToken(Long id, String fcmToken);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT m FROM MemberEntity m WHERE m.id = :id")
-    Optional<MemberEntity> findByIdWithLock(Long id);
 }

--- a/backend/src/main/java/com/zzang/chongdae/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package com.zzang.chongdae.member.repository;
 
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
@@ -15,4 +18,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     Optional<MemberEntity> findByLoginId(String loginId);
 
     boolean existsByIdAndFcmToken(Long id, String fcmToken);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM MemberEntity m WHERE m.id = :id")
+    Optional<MemberEntity> findByIdWithLock(Long id);
 }

--- a/backend/src/main/java/com/zzang/chongdae/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/repository/MemberRepository.java
@@ -20,6 +20,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     boolean existsByIdAndFcmToken(Long id, String fcmToken);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT m FROM MemberEntity m WHERE m.id = :id")
-    Optional<MemberEntity> findByIdWithLock(Long id);
+    @Query("SELECT m FROM MemberEntity m WHERE m.id = 1 or m.nickname = :nickname")
+    Optional<MemberEntity> findByNicknameWithLock(String nickname);
 }

--- a/backend/src/main/java/com/zzang/chongdae/member/repository/entity/MemberEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/repository/entity/MemberEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -50,12 +51,15 @@ public class MemberEntity extends BaseTimeEntity {
     @Column(unique = true)
     private String fcmToken;
 
+    @Version
+    private Long version;
+
     public MemberEntity(String nickname, AuthProvider provider, String loginId, String password, String fcmToken) {
-        this(null, nickname, provider, loginId, password, fcmToken);
+        this(null, nickname, provider, loginId, password, fcmToken, 0L);
     }
 
     public MemberEntity(String nickname, AuthProvider provider, String loginId, String password) {
-        this(null, nickname, provider, loginId, password, DEFAULT_FCM_TOKEN + UUID.randomUUID());
+        this(null, nickname, provider, loginId, password, DEFAULT_FCM_TOKEN + UUID.randomUUID(), 0L);
     }
 
     public boolean isSame(MemberEntity other) {

--- a/backend/src/main/java/com/zzang/chongdae/member/repository/entity/MemberEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/repository/entity/MemberEntity.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 public class MemberEntity extends BaseTimeEntity {
 
     private static final String DEFAULT_FCM_TOKEN = "invalid";
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -68,5 +68,9 @@ public class MemberEntity extends BaseTimeEntity {
 
     public void updateFcmTokenDefault() {
         this.fcmToken = DEFAULT_FCM_TOKEN + UUID.randomUUID();
+    }
+
+    public void updateNickName(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/member/repository/entity/MemberEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/repository/entity/MemberEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -51,15 +50,12 @@ public class MemberEntity extends BaseTimeEntity {
     @Column(unique = true)
     private String fcmToken;
 
-    @Version
-    private Long version;
-
     public MemberEntity(String nickname, AuthProvider provider, String loginId, String password, String fcmToken) {
-        this(null, nickname, provider, loginId, password, fcmToken, 0L);
+        this(null, nickname, provider, loginId, password, fcmToken);
     }
 
     public MemberEntity(String nickname, AuthProvider provider, String loginId, String password) {
-        this(null, nickname, provider, loginId, password, DEFAULT_FCM_TOKEN + UUID.randomUUID(), 0L);
+        this(null, nickname, provider, loginId, password, DEFAULT_FCM_TOKEN + UUID.randomUUID());
     }
 
     public boolean isSame(MemberEntity other) {

--- a/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
@@ -7,8 +7,6 @@ import com.zzang.chongdae.member.repository.MemberRepository;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.member.service.dto.NicknameRequest;
 import com.zzang.chongdae.member.service.dto.NicknameResponse;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,9 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class MemberService {
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
     private final MemberRepository memberRepository;
 
@@ -34,5 +29,4 @@ public class MemberService {
         targetMember.updateNickName(nickname);
         return new NicknameResponse(nickname);
     }
-
 }

--- a/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
@@ -30,8 +30,7 @@ public class MemberService {
                 .orElseThrow(() -> new MarketException(MemberErrorCode.NOT_FOUND));
         String nickname = request.nickname();
 
-        if (targetMember.getNickname().equals(nickname) &&
-                memberRepository.existsByNickname(nickname)) {
+        if (memberRepository.existsByNickname(nickname)) {
             throw new MarketException(MemberErrorCode.NICK_NAME_ALREADY_EXIST);
         }
 

--- a/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
     @Transactional
     public NicknameResponse changeNickname(MemberEntity member, NicknameRequest request) {
         String nickname = request.nickname();
-        MemberEntity targetMember = memberRepository.findByIdWithLock(member.getId())
+        MemberEntity targetMember = memberRepository.findById(member.getId())
                 .orElseThrow(() -> new MarketException(MemberErrorCode.NOT_FOUND));
         if (memberRepository.existsByNickname(nickname)) {
             throw new MarketException(MemberErrorCode.NICK_NAME_ALREADY_EXIST);

--- a/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
@@ -26,9 +26,7 @@ public class MemberService {
     @Transactional
     public NicknameResponse changeNickname(MemberEntity member, NicknameRequest request) {
         String nickname = request.nickname();
-        memberRepository.findByNicknameWithLock(request.nickname())
-                .orElseThrow(() -> new MarketException(MemberErrorCode.NOT_FOUND));
-        MemberEntity targetMember = memberRepository.findById(member.getId())
+        MemberEntity targetMember = memberRepository.findByIdWithLock(member.getId())
                 .orElseThrow(() -> new MarketException(MemberErrorCode.NOT_FOUND));
         if (memberRepository.existsByNickname(nickname)) {
             throw new MarketException(MemberErrorCode.NICK_NAME_ALREADY_EXIST);

--- a/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/service/MemberService.java
@@ -1,0 +1,39 @@
+package com.zzang.chongdae.member.service;
+
+import com.zzang.chongdae.global.config.WriterDatabase;
+import com.zzang.chongdae.global.exception.MarketException;
+import com.zzang.chongdae.member.exception.MemberErrorCode;
+import com.zzang.chongdae.member.repository.MemberRepository;
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.member.service.dto.NicknameRequest;
+import com.zzang.chongdae.member.service.dto.NicknameResponse;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final MemberRepository memberRepository;
+
+    @WriterDatabase
+    @Transactional
+    public NicknameResponse changeNickname(MemberEntity member, NicknameRequest request) {
+        MemberEntity targetMember = entityManager.merge(member);
+        String nickname = request.nickname();
+
+        if (targetMember.getNickname().equals(nickname) &&
+                memberRepository.existsByNickname(nickname)) {
+            throw new MarketException(MemberErrorCode.NICK_NAME_ALREADY_EXIST);
+        }
+
+        targetMember.updateNickName(nickname);
+        return new NicknameResponse(nickname);
+    }
+}

--- a/backend/src/main/java/com/zzang/chongdae/member/service/dto/NicknameRequest.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/service/dto/NicknameRequest.java
@@ -1,0 +1,10 @@
+package com.zzang.chongdae.member.service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// TODO: 닉네임 길이 설정 값으로 빼는 건 어떨까? 과한 추상화일까?
+public record NicknameRequest(@NotBlank(message = "닉네임을 입력해주세요.")
+                              @Size(max = 10, message = "닉네임의 최대 길이는 10자 미만입니다.")
+                              String nickname) {
+}

--- a/backend/src/main/java/com/zzang/chongdae/member/service/dto/NicknameResponse.java
+++ b/backend/src/main/java/com/zzang/chongdae/member/service/dto/NicknameResponse.java
@@ -1,0 +1,4 @@
+package com.zzang.chongdae.member.service.dto;
+
+public record NicknameResponse(String nickname) {
+}

--- a/backend/src/test/java/com/zzang/chongdae/member/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/member/integration/MemberIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.zzang.chongdae.member.integration;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceSnippetParameters.builder;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.zzang.chongdae.global.integration.IntegrationTest;
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.member.service.dto.NicknameRequest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+public class MemberIntegrationTest extends IntegrationTest {
+
+    @DisplayName("닉네임 변경")
+    @Nested
+    class ChangeNickname {
+
+        List<FieldDescriptor> requestDescriptors = List.of(
+                fieldWithPath("nickname").description("닉네임 (필수)")
+        );
+        ResourceSnippetParameters successSnippets = builder()
+                .summary("닉네임 변경")
+                .description("닉네임을 변경합니다.")
+                .requestFields(requestDescriptors)
+                .requestSchema(schema("NicknameRequest"))
+                .build();
+        ResourceSnippetParameters failSnippets = builder()
+                .responseFields(failResponseDescriptors)
+                .responseSchema(schema("NicknameFailResponse"))
+                .build();
+
+        MemberEntity member;
+
+        @BeforeEach
+        void setUp() {
+            member = memberFixture.createMember("poke");
+        }
+
+        @DisplayName("닉네임 변경에 성공한다.")
+        @Test
+        void should_changeNicknameSuccess_when_givenNicknameRequest() {
+            NicknameRequest request = new NicknameRequest("pokidoki");
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("change-nickname-success", resource(successSnippets)))
+                    .cookies(cookieProvider.createCookiesWithMember(member))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().patch("/member")
+                    .then().log().all()
+                    .statusCode(200);
+        }
+
+        @DisplayName("요청 값에 빈값이 들어오는 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_emptyValue() {
+            NicknameRequest request = new NicknameRequest("");
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("chnage-nickname-fail-request-with-empty", resource(failSnippets)))
+                    .cookies(cookieProvider.createCookiesWithMember(member))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().patch("/member")
+                    .then().log().all()
+                    .statusCode(400);
+        }
+
+        @DisplayName("닉네임의 허용 길이가 넘을 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_tooLongNickname() {
+            NicknameRequest request = new NicknameRequest("12345678901");
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("chnage-nickname-fail-request-with-too-long-nickname", resource(failSnippets)))
+                    .cookies(cookieProvider.createCookiesWithMember(member))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().patch("/member")
+                    .then().log().all()
+                    .statusCode(400);
+        }
+    }
+}

--- a/backend/src/test/java/com/zzang/chongdae/member/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/member/integration/MemberIntegrationTest.java
@@ -153,7 +153,7 @@ public class MemberIntegrationTest extends IntegrationTest {
                             .body(request)
                             .when().patch("/member")
                             .statusCode());
-            assertThat(statusCodes).containsExactlyInAnyOrder(200, 409);
+            assertThat(statusCodes).containsExactlyInAnyOrder(200, 200);
         }
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/member/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/member/integration/MemberIntegrationTest.java
@@ -130,7 +130,6 @@ public class MemberIntegrationTest extends IntegrationTest {
                             .body(request)
                             .when().patch("/member")
                             .statusCode());
-
             assertThat(statusCodes).containsExactlyInAnyOrder(200, 409);
         }
 

--- a/backend/src/test/java/com/zzang/chongdae/member/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/member/integration/MemberIntegrationTest.java
@@ -90,5 +90,21 @@ public class MemberIntegrationTest extends IntegrationTest {
                     .then().log().all()
                     .statusCode(400);
         }
+
+        @DisplayName("이미 존재하는 닉네임으로 변경할 경우 예외가 발생한다.")
+        @Test
+        void should_throwException_when_nicknameAlreadyExist() {
+            NicknameRequest request = new NicknameRequest("poke");
+
+            RestAssured.given(spec).log().all()
+                    .filter(document("chnage-nickname-fail-request-with-exist-nickname",
+                            resource(failSnippets)))
+                    .cookies(cookieProvider.createCookiesWithMember(member))
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().patch("/member")
+                    .then().log().all()
+                    .statusCode(409);
+        }
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/member/service/MemberServiceTest.java
@@ -1,0 +1,44 @@
+package com.zzang.chongdae.member.service;
+
+import com.zzang.chongdae.auth.config.TestAuthClientConfig;
+import com.zzang.chongdae.global.domain.MemberFixture;
+import com.zzang.chongdae.member.config.TestNicknameWordPickerConfig;
+import com.zzang.chongdae.member.repository.MemberRepository;
+import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.member.service.dto.NicknameRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = {TestNicknameWordPickerConfig.class,
+        TestAuthClientConfig.class})
+public class MemberServiceTest {
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    MemberFixture memberFixture;
+
+    @DisplayName("닉네임 변경에 성공한다.")
+    @Test
+    void should_changeNickname_when_givenNickname() {
+        // given
+        MemberEntity member = memberFixture.createMember("pokidoki");
+        NicknameRequest request = new NicknameRequest("dokipoki");
+
+        // when
+        memberService.changeNickname(member, request);
+
+        //then
+        Assertions.assertTrue(memberRepository.existsByNickname("dokipoki"));
+    }
+}

--- a/backend/src/test/java/com/zzang/chongdae/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/member/service/MemberServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.zzang.chongdae.auth.config.TestAuthClientConfig;
 import com.zzang.chongdae.global.domain.MemberFixture;
 import com.zzang.chongdae.global.exception.MarketException;
+import com.zzang.chongdae.global.service.ServiceTest;
 import com.zzang.chongdae.member.config.TestNicknameWordPickerConfig;
 import com.zzang.chongdae.member.repository.MemberRepository;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
@@ -21,7 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = {TestNicknameWordPickerConfig.class,
         TestAuthClientConfig.class})
-public class MemberServiceTest {
+public class MemberServiceTest extends ServiceTest {
 
     @Autowired
     MemberService memberService;
@@ -37,13 +38,13 @@ public class MemberServiceTest {
     void should_changeNickname_when_givenNickname() {
         // given
         MemberEntity member = memberFixture.createMember("pokidoki");
-        NicknameRequest request = new NicknameRequest("dokipoki");
+        NicknameRequest request = new NicknameRequest("test");
 
         // when
         memberService.changeNickname(member, request);
 
         //then
-        Assertions.assertTrue(memberRepository.existsByNickname("dokipoki"));
+        Assertions.assertTrue(memberRepository.existsByNickname("test"));
     }
 
     @DisplayName("이미 존재하는 닉네임이면 변경이 되지 않는다.")

--- a/backend/src/test/java/com/zzang/chongdae/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/member/service/MemberServiceTest.java
@@ -1,7 +1,11 @@
 package com.zzang.chongdae.member.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.zzang.chongdae.auth.config.TestAuthClientConfig;
 import com.zzang.chongdae.global.domain.MemberFixture;
+import com.zzang.chongdae.global.exception.MarketException;
 import com.zzang.chongdae.member.config.TestNicknameWordPickerConfig;
 import com.zzang.chongdae.member.repository.MemberRepository;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
@@ -40,5 +44,22 @@ public class MemberServiceTest {
 
         //then
         Assertions.assertTrue(memberRepository.existsByNickname("dokipoki"));
+    }
+
+    @DisplayName("이미 존재하는 닉네임이면 변경이 되지 않는다.")
+    @Test
+    void should_notChangeNickname_when_changeNicknameAlreadyExist() {
+        // given
+        MemberEntity member = memberFixture.createMember("pokidoki");
+        MemberEntity otherMember = memberFixture.createMember("dokipoki");
+
+        // when
+        NicknameRequest request = new NicknameRequest("dokipoki");
+        assertThatThrownBy(() -> memberService.changeNickname(member, request))
+                .isInstanceOf(MarketException.class);
+        MemberEntity actual = memberRepository.findById(member.getId()).get();
+
+        //then
+        assertThat(actual.getNickname()).isEqualTo(member.getNickname());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #699 

## ✨ 작업 내용
- 닉네임 변경 기능을 구현했습니다

## 📚 기타

닉네임 변경 기능을 추가하면서 발견한 문제들을 아래와 같이 해결했는데, 여러분들의 의견이 궁금합니다..! 

## 요약

1. **닉네임 변경 불가 문제 발견** 
    1. `argumentResolver`로 반환한 member는 비영속화 되기 때문 
    2. repository 재조회로 member 엔티티 재 영속화로 해결 그러나 select 쿼리 2번 날라가는것이 필연적임
    4. argumentResolver에서 레포지토리를 쓰지 않고 memberId dto만 받도록 변경 - 새 이슈 생성 후 처리 예정
    
2. **동시성 문제 발견**
    1.  **같은 회원이 같은 닉네임**으로 변경하는건 막을지 말지 판단이 서지 않음 
        1. 일단은 비관적 락을 이용해 막긴 했는데, 안막아도 크게 문제가 되보이진 않음 (의견 구함!!) 
    2. **다른 회원이 같은 닉네임으로 변경**할때 유니크 제약 예외 발생
        1. 영속성 컨택스트를 주입해서 강제로 flush하게 해서 서비스 로직에서 예외처리하게 함 이 구조에 대해 여러분의 생각은 어떤지 궁금 (아래의 리뷰 코멘트 확인)
        2. 서비스 테스트에 롤백 테스트 추가해서 닉네임 중복 시 변경 안되는 테스트 추가

## TLDR

### 문제 발생 1: 닉네임 변경 불가 문제 발견

로그인한 회원만 변경이 가능하므로 `ArgumentResolver`로 획득한 `member`를 재활용하여 닉네임을 업데이트하는 계획을 가졌죠. 그리고 서비스 테스트를 돌린 결과 **닉네임이 변경되지 않은 문제가 발생했습니다.**

JPA를 사용하고 있기 때문에`@Transactional`어노테이션이 붙은 메서드가 호출이 종료되면 `EntityManager`가 변경 감지(dirty-check)한 후 변경된 엔티티의 필드를 DB에 반영하기 위해 `update`쿼리문이 실행되는 걸로 알고있어요.

원인 분석 결과, `changeNickname` 메서드에서 매개변수로 받은 `member`가 **준영속(detach) 상태였기 때문에 변경 감지가 되지 않았던 문제**였습니다. **OSIV(Open-Session-In-View)옵션을 끈 상태**로 `ArgumentResolver`에서 반환하는 엔티티는 더이상  영속성 컨텍스트에서 관리하지 않는다고 합니다.

원인을 발견할 수 있었던 방법은 `MemberService`에 영속성 컨텍스트를  주입시켰고 `entitymanager.contains(member)` 결과가 `false`가 나오는지 확인했습니다. 확실히 false값이 나타났습니다.

### 해결 방안

#### 1. OSIV를 다시 킨다  (X)

OSIV를 다시 키면 해결할 수 있지만,  reader-writer DB 분리와 성능최적화로 현재 끈 상태를 유지해야 합니다.

#### 2. MemberService에 영속성 컨텍스트 주입 (X)

영속성 컨텍스트를 주입해서 `member`로 영속화 시켜서 해결하려고 했습니다만, 영속화를 하면 select 쿼리가 한번 더 날라가는 것을 확인했습니다. 

이미 동시성 문제 해결을 위해 비관적 락 조회 쿼리를 날리기 때문에 영속성 컨텍스트를 주입하지 않았습니다. 

#### 3. 매개변수로 받은 member 객체 id를 활용해 새로운 entity로 변경하기 (O)

member 엔티티의 닉테임을 직접 변경하지 않고 비관적 락 조회로 얻은 엔티티를 활용해서 닉네임을 변경하고 있습니다. 동시성 문제(두 사람이 하나의 공통 닉네임, 한사람이 동시에 여러번 요청)까지 해결하고 있어 현 상태를 유지하고 있습니다.

### 문제 발생 2 : 동시성 문제

**동일한 회원**이 **같은 닉네임으로 동시에 변경**하는 것과 서로 **다른 닉네임으로 동시에 변경 하는건** 문제로 정의하지 않았으나, **같은 닉네임으로 동시에 변경** 할 때 비관적 조회 락을 걸어 하나의 요청만 성공하도록 작성했습니다. 

장점으로 동기화를 통해 닉네임 변경 로직의 일관성을 보장합니다. 단점으로는 비관적을 락을 수행하기에 닉네임 변경 로직의 성능저하가 있을 것이라고 생각했습니다. 그러나 닉네임 변경 로직은 다른 로직에 비해 많이 사용할 것으로 판단하지 않아서 현상 유지 했습니다.

하지만 닉네임 변경에 비관적 락이 꼭 필요한가?에 대해선 의견이 갈릴것 같은데요 여러분들의 생각은 어떤지 궁금합니다.

위의 문제와 별개로 **다른 회원이 같은 닉네임으로 동시에 변경 요청**하면 동시성 문제가 발생하게 됩니다. 이는 같은 회원의 레코드 락을 거는것으로 해결할 수 없기 때문에 **이미 걸려있는 유니크 제약조건을 활용했고,** 예외는 서비스 로직에서 처리하도록 코드를 작성하려고 했습니다.

그러나 변경감지는 트렌젝션이 끝날 때 업데이트 쿼리가날라가기 때문에 이때 유니크 제약조건 위반이 발생하면 GlobalExceptionHandler에서 처리해줘야 하고 이 시점엔 어떤 서비스에서 예외 발생했는지 확인하기 위한 코드를 작성해야 하니 GlobalExceptionHandler 코드의 복잡성이 늘어나는건 필연적이라고 생각했습니다.

이를 해결하기 위해 영속성 컨텍스트를 주입해 강제로 flush하여 예외 발생시 custom오류(닉네임중복)를 뱉도록 설계했습니다. 그러나 트랜젝션 처리 중 강제로 flush를 하면 트렌젝션 경계 관리가 힘들어 질수 있다고 합니다.

이렇게 하면 GlobalExceptionHandler에서 분기처리하지 않고 문제가 발생한 서비스 메서드에서 예외처리를 할 수 있어서 코드의 복잡성을 효율적으로 관리한 선택이라고 생각하는데 여러분의 생각은 어때요? 
