### PR TITLE
fix: image url 프로파일 별로 설정하도록 수정

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingReadOnlyWebPageController.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/controller/OfferingReadOnlyWebPageController.java
@@ -3,6 +3,7 @@ package com.zzang.chongdae.offering.controller;
 import com.zzang.chongdae.offering.service.OfferingService;
 import com.zzang.chongdae.offering.service.dto.OfferingMetaResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,16 +15,21 @@ public class OfferingReadOnlyWebPageController {
 
     private final OfferingService offeringService;
 
+    @Value("${storage.resourceHost}")
+    private String resourceHost;
+
     @GetMapping("/read-only/web/offerings/{offering-id}")
     String renderOfferingDetail(@PathVariable("offering-id") Long offeringId, Model model) {
         OfferingMetaResponse response = offeringService.getOfferingMetaInfo(offeringId);
         model.addAttribute("offeringTitle", response.title());
         model.addAttribute("thumbnailUrl", response.thumbnailUrl());
+        model.addAttribute("resourceHost", resourceHost);
         return "detail";
     }
 
     @GetMapping("/read-only/web/offerings")
-    String renderOffering() {
+    String renderOffering(Model model) {
+        model.addAttribute("resourceHost", resourceHost);
         return "index";
     }
 }

--- a/backend/src/main/resources/templates/detail.html
+++ b/backend/src/main/resources/templates/detail.html
@@ -108,8 +108,9 @@
         </div>
     </div>
 
-    <script>
-        const defaultThumbnailUrl = 'https://d3a5rfnjdz82qu.cloudfront.net/chongdae-market/images/common/no-image.png';
+    <script th:inline="javascript">
+        const resourceHost = [[${resourceHost}]]
+        const defaultThumbnailUrl = `https://${resourceHost}/chongdae-market/images/common/no-image.png`;
         const playStoreUrl = "https://play.google.com/store/apps/details?id=com.zzang.chongdae";
         async function fetchOfferingDetails(offeringId) {
             try {

--- a/backend/src/main/resources/templates/detail.html
+++ b/backend/src/main/resources/templates/detail.html
@@ -109,7 +109,7 @@
     </div>
 
     <script th:inline="javascript">
-        const resourceHost = [[${resourceHost}]]
+        const resourceHost = [[${resourceHost}]];
         const defaultThumbnailUrl = `https://${resourceHost}/chongdae-market/images/common/no-image.png`;
         const playStoreUrl = "https://play.google.com/store/apps/details?id=com.zzang.chongdae";
         async function fetchOfferingDetails(offeringId) {

--- a/backend/src/main/resources/templates/index.html
+++ b/backend/src/main/resources/templates/index.html
@@ -226,7 +226,7 @@
            </div>
        </div>
     <script th:inline="javascript">
-        const resourceHost = [[${resourceHost}]]
+        const resourceHost = [[${resourceHost}]];
         let currentFilter = '';
         let lastId = -1;
         let isLoading = false;

--- a/backend/src/main/resources/templates/index.html
+++ b/backend/src/main/resources/templates/index.html
@@ -225,12 +225,13 @@
                <!-- offering list -->
            </div>
        </div>
-    <script>
+    <script th:inline="javascript">
+        const resourceHost = [[${resourceHost}]]
         let currentFilter = '';
         let lastId = -1;
         let isLoading = false;
         let search = '';
-        const defaultThumbnailUrl = 'https://d3a5rfnjdz82qu.cloudfront.net/chongdae-market/images/common/no-image.png';
+        const defaultThumbnailUrl = `https://${resourceHost}/images/common/no-image.png`;
 
         async function fetchOfferings(filter = '', lastId = -1, search = '') {
             const response = await fetch(`/read-only/offerings?filter=${filter}${lastId !== -1 ? '&last-id=' + lastId : ''}${search !== '' ? '&search=' + encodeURIComponent(search) : ''}`);


### PR DESCRIPTION
## 📌 관련 이슈
close #714 
## ✨ 작업 내용
* 웹 뷰 페이지 이미지를 불러오지 못해서 수정합니다.

## 📚 기타
* 개발 image host와 운영 host가 상이하여 `@Values`를 사용하여 설정값을 땡겨왔습니다!
* 타임리프의 입력값 필터링을 적용하기 위해 th:inline="javascript" 를 추가했습니다.
