### PR TITLE
feat:  참여자 목록 화면에 개수 및 예상 금액 표시

### DIFF
--- a/android/app/src/main/java/com/zzang/chongdae/data/remote/dto/response/participants/RemoteParticipant.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/remote/dto/response/participants/RemoteParticipant.kt
@@ -7,4 +7,8 @@ import kotlinx.serialization.Serializable
 data class RemoteParticipant(
     @SerialName("nickname")
     val nickname: String,
+    @SerialName("count")
+    val count: Int,
+    @SerialName("price")
+    val price: Int,
 )

--- a/android/app/src/main/java/com/zzang/chongdae/data/remote/dto/response/participants/RemoteProposer.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/remote/dto/response/participants/RemoteProposer.kt
@@ -7,4 +7,8 @@ import kotlinx.serialization.Serializable
 data class RemoteProposer(
     @SerialName("nickname")
     val nickname: String,
+    @SerialName("count")
+    val count: Int,
+    @SerialName("price")
+    val price: Int,
 )

--- a/android/app/src/main/java/com/zzang/chongdae/data/remote/mapper/participant/ParticipantsMapper.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/data/remote/mapper/participant/ParticipantsMapper.kt
@@ -21,12 +21,16 @@ fun ParticipantsResponse.toDomain(): Participants {
 fun RemoteProposer.toDomain(): Proposer {
     return Proposer(
         nickname = this.nickname,
+        count = this.count,
+        price = this.price,
     )
 }
 
 fun RemoteParticipant.toDomain(): Participant {
     return Participant(
         nickname = this.nickname,
+        count = this.count,
+        price = this.price,
     )
 }
 

--- a/android/app/src/main/java/com/zzang/chongdae/domain/model/participant/Participant.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/domain/model/participant/Participant.kt
@@ -2,4 +2,6 @@ package com.zzang.chongdae.domain.model.participant
 
 data class Participant(
     val nickname: String,
+    val count: Int,
+    val price: Int,
 )

--- a/android/app/src/main/java/com/zzang/chongdae/domain/model/participant/Proposer.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/domain/model/participant/Proposer.kt
@@ -2,4 +2,6 @@ package com.zzang.chongdae.domain.model.participant
 
 data class Proposer(
     val nickname: String,
+    val count: Int,
+    val price: Int,
 )

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/commentdetail/model/participants/ParticipantUiModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/commentdetail/model/participants/ParticipantUiModel.kt
@@ -4,11 +4,15 @@ import com.zzang.chongdae.domain.model.participant.Participant
 
 data class ParticipantUiModel(
     val nickname: String,
+    val count: Int,
+    val price: Int,
 ) {
     companion object {
         fun Participant.toUiModel(): ParticipantUiModel {
             return ParticipantUiModel(
                 nickname = nickname,
+                count = count,
+                price = price,
             )
         }
     }

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/commentdetail/model/participants/ProposerUiModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/commentdetail/model/participants/ProposerUiModel.kt
@@ -4,11 +4,15 @@ import com.zzang.chongdae.domain.model.participant.Proposer
 
 data class ProposerUiModel(
     val nickname: String,
+    val count: Int,
+    val price: Int,
 ) {
     companion object {
         fun Proposer.toUiModel(): ProposerUiModel {
             return ProposerUiModel(
                 nickname = nickname,
+                count = count,
+                price = price,
             )
         }
     }

--- a/android/app/src/main/res/layout/activity_comment_detail.xml
+++ b/android/app/src/main/res/layout/activity_comment_detail.xml
@@ -335,11 +335,33 @@
                 android:text="@{vm.participants.proposer.nickname}"
                 android:textColor="@color/gray_600"
                 android:textSize="@dimen/size_14"
-                app:layout_constraintBottom_toBottomOf="@id/iv_proposer"
                 app:layout_constraintStart_toEndOf="@id/iv_proposer"
                 app:layout_constraintTop_toTopOf="@id/iv_proposer"
                 app:layout_constraintVertical_bias="0.4"
                 tools:text="총대 닉네임" />
+
+            <View
+                android:id="@+id/v_divider"
+                android:layout_width="@dimen/size_1"
+                android:layout_height="@dimen/size_10"
+                android:layout_marginTop="@dimen/size_3"
+                android:background="@color/main_color"
+                app:layout_constraintStart_toStartOf="@id/tv_proposer"
+                app:layout_constraintTop_toBottomOf="@id/tv_proposer" />
+
+            <TextView
+                android:id="@+id/tv_participant_info"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/size_3"
+                android:fontFamily="@font/suit_medium"
+                android:text='@{String.format(@string/participant_info, vm.participants.proposer.count, vm.participants.proposer.price)}'
+                android:textColor="@color/gray_600"
+                android:textSize="@dimen/size_10"
+                app:layout_constraintBottom_toBottomOf="@id/v_divider"
+                app:layout_constraintStart_toStartOf="@id/v_divider"
+                app:layout_constraintTop_toTopOf="@id/v_divider"
+                tools:text="1개  50,000원" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_offering_members"
@@ -354,29 +376,6 @@
                 app:layout_constraintTop_toBottomOf="@id/iv_proposer"
                 tools:itemCount="15"
                 tools:listitem="@layout/item_offering_member" />
-
-            <TextView
-                android:id="@+id/tv_comment_detail_expected_price"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/suit_semibold"
-                android:text="@string/comment_detail_expected_price"
-                android:textColor="@color/gray_500"
-                app:layout_constraintBottom_toTopOf="@id/horizon_line"
-                app:layout_constraintStart_toStartOf="@id/tv_offering_members"
-                app:layout_constraintTop_toBottomOf="@id/rv_offering_members" />
-
-            <TextView
-                android:id="@+id/tv_price"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/margin_20"
-                android:fontFamily="@font/suit_semibold"
-                android:text='@{String.format(@string/all_money_amount_text, vm.participants.price)}'
-                android:textColor="@color/main_color"
-                app:layout_constraintBottom_toTopOf="@id/horizon_line"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/rv_offering_members" />
 
             <View
                 android:id="@+id/horizon_line"

--- a/android/app/src/main/res/layout/item_offering_member.xml
+++ b/android/app/src/main/res/layout/item_offering_member.xml
@@ -10,7 +10,6 @@
             type="com.zzang.chongdae.presentation.view.commentdetail.model.participants.ParticipantUiModel" />
     </data>
 
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
@@ -31,15 +30,36 @@
             android:id="@+id/tv_participant"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/size_15"
+            android:layout_marginStart="12dp"
             android:fontFamily="@font/suit_medium"
+            android:text="@{participant.nickname}"
             android:textColor="@color/gray_600"
             android:textSize="@dimen/size_14"
-            android:text="@{participant.nickname}"
-            app:layout_constraintBottom_toBottomOf="@+id/iv_profile"
             app:layout_constraintStart_toEndOf="@id/iv_profile"
-            app:layout_constraintTop_toTopOf="@+id/iv_profile"
-            app:layout_constraintVertical_bias="0.4"
+            app:layout_constraintTop_toTopOf="@id/iv_profile"
             tools:text="참여자1" />
+
+        <View
+            android:id="@+id/v_divider"
+            android:layout_width="@dimen/size_1"
+            android:layout_height="@dimen/size_10"
+            android:layout_marginTop="@dimen/size_3"
+            android:background="@color/gray_400"
+            app:layout_constraintStart_toStartOf="@id/tv_participant"
+            app:layout_constraintTop_toBottomOf="@id/tv_participant" />
+
+        <TextView
+            android:id="@+id/tv_participant_info"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/size_3"
+            android:fontFamily="@font/suit_medium"
+            android:text='@{String.format(@string/participant_info, participant.count, participant.price)}'
+            android:textColor="@color/gray_600"
+            android:textSize="@dimen/size_10"
+            app:layout_constraintBottom_toBottomOf="@id/v_divider"
+            app:layout_constraintStart_toStartOf="@id/v_divider"
+            app:layout_constraintTop_toTopOf="@id/v_divider"
+            tools:text="1개  50,000원" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -26,7 +26,6 @@
     <string name="report_url">https://docs.google.com/forms/d/e/1FAIpQLSdyHhWqwY0-iJsa6MrbD2f3rdES4dhXekkRbQ2T3HmnIgV1TA/viewform</string>
     <string name="all_due_datetime">yyyy년 M월 d일</string>
 
-
     <!--    login-->
     <string name="login_with_kakao">카카오톡으로 \n간편하게 <font color="#F15642">공동구매</font> 시작하기</string>
     <string name="login_with_kakao_button">카카오 로그인</string>
@@ -110,6 +109,7 @@
     <string name="offering_members">참여자 목록 (%d명/%d명)</string>
     <string name="comment_detail_expected_price">예상 공동구매 엔빵 가격</string>
     <string name="comment_detail_exit_alert">공동구매에서 퇴장하시겠습니까?</string>
+    <string name="participant_info">%1$d개 %2$d원</string>
 
     <!--    offering_write-->
     <string name="write_information_message_essential"><font color="#F15642">공동구매</font> 물품의 필수 정보를\n입력해 주세요.</string>


### PR DESCRIPTION
## 📌 관련 이슈
close #717

## ✨ 작업 내용

- 참여자 목록 화면에 개수 표시

- 참여자 목록 화면에 예상 금액 표시


## 📚 기타

변경된 화면은 아래와 같습니다!

<img width="336" alt="image" src="https://github.com/user-attachments/assets/d6ca3619-aa56-4e09-b8d2-ba09478ee039" />

