### PR TITLE
feat: 중복 참여 방지를 위한 잠금 종류 변경

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/OfferingRepository.java
@@ -1,12 +1,10 @@
 package com.zzang.chongdae.offering.repository;
 
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
-import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface OfferingRepository extends JpaRepository<OfferingEntity, Long>, CustomizedOfferingRepository {
@@ -28,8 +26,4 @@ public interface OfferingRepository extends JpaRepository<OfferingEntity, Long>,
                 AND (o.offeringStatus IN ('AVAILABLE', 'FULL', 'IMMINENT'))
             """)
     List<OfferingEntity> findByMeetingDateAndOfferingStatusNotConfirmed(LocalDateTime meetingDate);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT o FROM OfferingEntity o WHERE o.id = :id")
-    Optional<OfferingEntity> findByIdWithLock(Long id);
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
@@ -36,7 +36,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EqualsAndHashCode(of = "id", callSuper = false)
-@SQLDelete(sql = "UPDATE offering SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE offering SET is_deleted = true, version = version + 1 WHERE id = ? AND version = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "offering")
 @Entity

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
@@ -18,6 +18,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -107,6 +108,9 @@ public class OfferingEntity extends BaseTimeEntity {
     @ColumnDefault("false")
     private Boolean isDeleted;
 
+    @Version
+    private Long version;
+
     public OfferingEntity(MemberEntity member, String title, String description, String thumbnailUrl, String productUrl,
                           LocalDateTime meetingDate, String meetingAddress, String meetingAddressDetail,
                           String meetingAddressDong,
@@ -115,7 +119,7 @@ public class OfferingEntity extends BaseTimeEntity {
                           OfferingStatus offeringStatus, CommentRoomStatus roomStatus) {
         this(null, member, title, description, thumbnailUrl, productUrl, meetingDate, meetingAddress,
                 meetingAddressDetail, meetingAddressDong, totalCount, currentCount, totalPrice,
-                originPrice, discountRate, offeringStatus, roomStatus, false);
+                originPrice, discountRate, offeringStatus, roomStatus, false, null);
     }
 
     public void participate(int participationCount) {

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -33,7 +33,7 @@ public class OfferingMemberService {
     @WriterDatabase
     @Transactional
     public Long participate(ParticipationRequest request, MemberEntity member) {
-        OfferingEntity offering = offeringRepository.findByIdWithLock(request.offeringId())
+        OfferingEntity offering = offeringRepository.findById(request.offeringId())
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         validateParticipate(offering, member, request.participationCount());
 

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
@@ -196,9 +196,9 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
                             .contentType(ContentType.JSON)
                             .body(request)
                             .when().post("/participations")
-                            .statusCode(), 5);
+                            .statusCode(), 2);
 
-            assertThat(statusCodes).containsExactlyInAnyOrder(201, 400, 400, 400, 400);
+            assertThat(statusCodes).containsExactly(201, 409);
         }
 
         @DisplayName("다른 사용자가 같은 공모에 동시에 참여할 경우 예외가 발생한다.")
@@ -229,7 +229,7 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
                             .when().post("/participations")
                             .statusCode());
 
-            assertThat(statusCodes).containsExactlyInAnyOrder(201, 400);
+            assertThat(statusCodes).containsExactlyInAnyOrder(201, 409);
         }
 
         @DisplayName("두 참여자가 한 공모에 동시에 참여 할 때 총 개수가 넘을 경우 한 참여자만 참여할 수 있다.")
@@ -259,7 +259,7 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
                             .body(request2)
                             .when().post("/participations")
                             .statusCode());
-            assertThat(statusCodes).containsExactlyInAnyOrder(201, 400);
+            assertThat(statusCodes).containsExactlyInAnyOrder(201, 409);
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #721 
## ✨ 작업 내용
이전에 중복 참여 방지를 위해 아래 총 네 가지 방안을 적용해본 후 최종적으로 비관적 쓰기 잠금을 적용하였습니다. (관련 PR #673)
성능테스트를 통해 비관적 쓰기 잠금과 낙관적 잠금 간 큰 차이가 없음을 확인하여 안정성이 높은 비관적 쓰기 잠금을 택했었는데요.

사실 중복 참여의 경우 발생 확률이 매우 낮은 케이스입니다. 따라서 이를 위해 모든 참여 API에서 데이터베이스 잠금을 획득하는 것은 불필요하다고 생각하였습니다.

결과적으로는 기존의 비관적 쓰기 잠금을 적용하던 방식에서 낙관적 잠금을 적용하는 방식으로 변경하였습니다.

## 📚 기타
