### PR TITLE
fix: 안드로이드 빌드 실패 수정

### DIFF
--- a/android/app/src/test/java/com/zzang/chongdae/repository/FakeOfferingDetailRepository.kt
+++ b/android/app/src/test/java/com/zzang/chongdae/repository/FakeOfferingDetailRepository.kt
@@ -11,7 +11,10 @@ class FakeOfferingDetailRepository() : OfferingDetailRepository {
         return Result.Success(TestFixture.OFFERING_DETAIL_STUB)
     }
 
-    override suspend fun saveParticipation(offeringId: Long): Result<Unit, DataError.Network> {
+    override suspend fun saveParticipation(
+        offeringId: Long,
+        participationCount: Int,
+    ): Result<Unit, DataError.Network> {
         return Result.Success(Unit)
     }
 

--- a/android/app/src/test/java/com/zzang/chongdae/util/TestFixture.kt
+++ b/android/app/src/test/java/com/zzang/chongdae/util/TestFixture.kt
@@ -91,10 +91,10 @@ object TestFixture {
 
     val participants: Participants =
         Participants(
-            proposer = Proposer(nickname = "proposer nickname"),
+            proposer = Proposer(nickname = "proposer nickname", count = 1, price = 1000),
             participants =
                 listOf(
-                    Participant(nickname = "participant nickname"),
+                    Participant(nickname = "participant nickname", count = 1, price = 1000),
                 ),
             participantCount = ParticipantCount(currentCount = 1, totalCount = 4),
             price = 1000,


### PR DESCRIPTION
## 📌 관련 이슈
close #733
## ✨ 작업 내용
- 안드로이드 빌드 실패 수정

## 📚 기타
default 브랜치 변경으로 cicd 가 안돌아가고 있는걸 이제야 깨달은.... 
빨리 고치자요...