### PR TITLE
feat: 안드로이드 세팅에서 푸시알림 해제 시 앱 내 UI가 그것을 알려주도록 변경

### DIFF
--- a/android/app/src/main/java/com/zzang/chongdae/presentation/util/BindingAdapters.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/util/BindingAdapters.kt
@@ -62,6 +62,11 @@ fun View.setIsVisible(isVisible: Boolean) {
     visibility = if (isVisible) View.VISIBLE else View.GONE
 }
 
+@BindingAdapter("isVisibleOrInvisible")
+fun View.setIsVisibleOrInvisible(isVisible: Boolean) {
+    visibility = if (isVisible) View.VISIBLE else View.INVISIBLE
+}
+
 @BindingAdapter("formattedDate")
 fun TextView.bindFormattedDate(datetime: LocalDateTime?) {
     this.text =

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/mypage/MyPageFragment.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/mypage/MyPageFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -100,5 +101,12 @@ class MyPageFragment : Fragment() {
             screenName = "MyPageFragment",
             screenClass = this::class.java.simpleName,
         )
+        updateNoficationStatus()
+    }
+
+    private fun updateNoficationStatus() {
+        val areNotificationEnabled =
+            NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
+        viewModel.updateNotificationStatus(areNotificationEnabled)
     }
 }

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/mypage/MyPageViewModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/mypage/MyPageViewModel.kt
@@ -21,94 +21,101 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel
-    @Inject
-    constructor(
-        getNickNameUseCase: GetNickNameUseCase,
-        private val getNotificationActivateUseCase: GetNotificationActivateUseCase,
-        private val getNotificationImportanceUseCase: GetNotificationImportanceUseCase,
-        private val setNotificationActivateUseCase: SetNotificationActivateUseCase,
-        private val setNotificationImportanceUseCase: SetNotificationImportanceUseCase,
-        private val logoutUseCase: LogoutUseCase,
-    ) : ViewModel(), OnAlertClickListener {
-        val nickName: LiveData<String?> = getNickNameUseCase().asLiveData()
+@Inject
+constructor(
+    getNickNameUseCase: GetNickNameUseCase,
+    private val getNotificationActivateUseCase: GetNotificationActivateUseCase,
+    private val getNotificationImportanceUseCase: GetNotificationImportanceUseCase,
+    private val setNotificationActivateUseCase: SetNotificationActivateUseCase,
+    private val setNotificationImportanceUseCase: SetNotificationImportanceUseCase,
+    private val logoutUseCase: LogoutUseCase,
+) : ViewModel(), OnAlertClickListener {
+    val nickName: LiveData<String?> = getNickNameUseCase().asLiveData()
 
-        private val _openUrlInBrowserEvent = MutableSingleLiveData<String>()
-        val openUrlInBrowserEvent: SingleLiveData<String> get() = _openUrlInBrowserEvent
+    private val _openUrlInBrowserEvent = MutableSingleLiveData<String>()
+    val openUrlInBrowserEvent: SingleLiveData<String> get() = _openUrlInBrowserEvent
 
-        private val _logoutEvent = MutableSingleLiveData<Unit>()
-        val logoutEvent: SingleLiveData<Unit> get() = _logoutEvent
+    private val _logoutEvent = MutableSingleLiveData<Unit>()
+    val logoutEvent: SingleLiveData<Unit> get() = _logoutEvent
 
-        private val _showAlertEvent = MutableSingleLiveData<Unit>()
-        val showAlertEvent: SingleLiveData<Unit> get() = _showAlertEvent
+    private val _showAlertEvent = MutableSingleLiveData<Unit>()
+    val showAlertEvent: SingleLiveData<Unit> get() = _showAlertEvent
 
-        private val _alertCancelEvent = MutableSingleLiveData<Unit>()
-        val alertCancelEvent: SingleLiveData<Unit> get() = _alertCancelEvent
+    private val _alertCancelEvent = MutableSingleLiveData<Unit>()
+    val alertCancelEvent: SingleLiveData<Unit> get() = _alertCancelEvent
 
-        private val termsOfUseUrl =
-            "https://silent-apparatus-578.notion.site/f1f5cd1609d4469dba3ab7d0f95c183c?pvs=4"
-        private val privacyUrl =
-            "https://silent-apparatus-578.notion.site/f1f5cd1609d4469dba3ab7d0f95c183c?pvs=4"
-        private val withdrawalUrl = "https://forms.gle/z5MUzVTUoyunfqEu8"
+    private val termsOfUseUrl =
+        "https://silent-apparatus-578.notion.site/f1f5cd1609d4469dba3ab7d0f95c183c?pvs=4"
+    private val privacyUrl =
+        "https://silent-apparatus-578.notion.site/f1f5cd1609d4469dba3ab7d0f95c183c?pvs=4"
+    private val withdrawalUrl = "https://forms.gle/z5MUzVTUoyunfqEu8"
 
-        val isNotificationActivate = MutableLiveData(true)
-        val isNotificationImportanceHigh = MutableLiveData(true)
+    val isNotificationActivate = MutableLiveData(true)
+    val isNotificationImportanceHigh = MutableLiveData(true)
 
-        init {
-            viewModelScope.launch {
-                initNotificationSwitches()
-            }
-        }
+    private val _areNotificationsEnabled = MutableLiveData<Boolean>()
+    val areNotificationsEnabled: LiveData<Boolean> get() = _areNotificationsEnabled
 
-        private suspend fun initNotificationSwitches() {
-            isNotificationActivate.value = getNotificationActivateUseCase()
-            isNotificationImportanceHigh.value =
-                getNotificationImportanceUseCase() == NotificationManager.IMPORTANCE_HIGH
-        }
-
-        fun onClickTermsOfUse() {
-            _openUrlInBrowserEvent.setValue(termsOfUseUrl)
-        }
-
-        fun onClickPrivacy() {
-            _openUrlInBrowserEvent.setValue(privacyUrl)
-        }
-
-        fun onClickLogout() {
-            _showAlertEvent.setValue(Unit)
-        }
-
-        fun onClickWithdrawal() {
-            _openUrlInBrowserEvent.setValue(withdrawalUrl)
-        }
-
-        override fun onClickConfirm() {
-            viewModelScope.launch {
-                logoutUseCase()
-                _logoutEvent.setValue(Unit)
-            }
-        }
-
-        override fun onClickCancel() {
-            _alertCancelEvent.setValue(Unit)
-        }
-
-        fun onNotificationActivateSwitchChanged(isChecked: Boolean) {
-            isNotificationActivate.value = isChecked
-            viewModelScope.launch {
-                setNotificationActivateUseCase(isChecked)
-            }
-        }
-
-        fun onNotificationImportanceSwitchChanged(isChecked: Boolean) {
-            isNotificationImportanceHigh.value = isChecked
-            viewModelScope.launch {
-                val importance =
-                    if (isChecked) {
-                        NotificationManager.IMPORTANCE_HIGH
-                    } else {
-                        NotificationManager.IMPORTANCE_DEFAULT
-                    }
-                setNotificationImportanceUseCase(importance)
-            }
+    init {
+        viewModelScope.launch {
+            initNotificationSwitches()
         }
     }
+
+    private suspend fun initNotificationSwitches() {
+        isNotificationActivate.value = getNotificationActivateUseCase()
+        isNotificationImportanceHigh.value =
+            getNotificationImportanceUseCase() == NotificationManager.IMPORTANCE_HIGH
+    }
+
+    fun onClickTermsOfUse() {
+        _openUrlInBrowserEvent.setValue(termsOfUseUrl)
+    }
+
+    fun onClickPrivacy() {
+        _openUrlInBrowserEvent.setValue(privacyUrl)
+    }
+
+    fun onClickLogout() {
+        _showAlertEvent.setValue(Unit)
+    }
+
+    fun onClickWithdrawal() {
+        _openUrlInBrowserEvent.setValue(withdrawalUrl)
+    }
+
+    override fun onClickConfirm() {
+        viewModelScope.launch {
+            logoutUseCase()
+            _logoutEvent.setValue(Unit)
+        }
+    }
+
+    override fun onClickCancel() {
+        _alertCancelEvent.setValue(Unit)
+    }
+
+    fun onNotificationActivateSwitchChanged(isChecked: Boolean) {
+        isNotificationActivate.value = isChecked
+        viewModelScope.launch {
+            setNotificationActivateUseCase(isChecked)
+        }
+    }
+
+    fun onNotificationImportanceSwitchChanged(isChecked: Boolean) {
+        isNotificationImportanceHigh.value = isChecked
+        viewModelScope.launch {
+            val importance =
+                if (isChecked) {
+                    NotificationManager.IMPORTANCE_HIGH
+                } else {
+                    NotificationManager.IMPORTANCE_DEFAULT
+                }
+            setNotificationImportanceUseCase(importance)
+        }
+    }
+
+    fun updateNotificationStatus(enabled: Boolean) {
+        _areNotificationsEnabled.value = enabled
+    }
+}

--- a/android/app/src/main/java/com/zzang/chongdae/presentation/view/mypage/MyPageViewModel.kt
+++ b/android/app/src/main/java/com/zzang/chongdae/presentation/view/mypage/MyPageViewModel.kt
@@ -21,101 +21,101 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel
-@Inject
-constructor(
-    getNickNameUseCase: GetNickNameUseCase,
-    private val getNotificationActivateUseCase: GetNotificationActivateUseCase,
-    private val getNotificationImportanceUseCase: GetNotificationImportanceUseCase,
-    private val setNotificationActivateUseCase: SetNotificationActivateUseCase,
-    private val setNotificationImportanceUseCase: SetNotificationImportanceUseCase,
-    private val logoutUseCase: LogoutUseCase,
-) : ViewModel(), OnAlertClickListener {
-    val nickName: LiveData<String?> = getNickNameUseCase().asLiveData()
+    @Inject
+    constructor(
+        getNickNameUseCase: GetNickNameUseCase,
+        private val getNotificationActivateUseCase: GetNotificationActivateUseCase,
+        private val getNotificationImportanceUseCase: GetNotificationImportanceUseCase,
+        private val setNotificationActivateUseCase: SetNotificationActivateUseCase,
+        private val setNotificationImportanceUseCase: SetNotificationImportanceUseCase,
+        private val logoutUseCase: LogoutUseCase,
+    ) : ViewModel(), OnAlertClickListener {
+        val nickName: LiveData<String?> = getNickNameUseCase().asLiveData()
 
-    private val _openUrlInBrowserEvent = MutableSingleLiveData<String>()
-    val openUrlInBrowserEvent: SingleLiveData<String> get() = _openUrlInBrowserEvent
+        private val _openUrlInBrowserEvent = MutableSingleLiveData<String>()
+        val openUrlInBrowserEvent: SingleLiveData<String> get() = _openUrlInBrowserEvent
 
-    private val _logoutEvent = MutableSingleLiveData<Unit>()
-    val logoutEvent: SingleLiveData<Unit> get() = _logoutEvent
+        private val _logoutEvent = MutableSingleLiveData<Unit>()
+        val logoutEvent: SingleLiveData<Unit> get() = _logoutEvent
 
-    private val _showAlertEvent = MutableSingleLiveData<Unit>()
-    val showAlertEvent: SingleLiveData<Unit> get() = _showAlertEvent
+        private val _showAlertEvent = MutableSingleLiveData<Unit>()
+        val showAlertEvent: SingleLiveData<Unit> get() = _showAlertEvent
 
-    private val _alertCancelEvent = MutableSingleLiveData<Unit>()
-    val alertCancelEvent: SingleLiveData<Unit> get() = _alertCancelEvent
+        private val _alertCancelEvent = MutableSingleLiveData<Unit>()
+        val alertCancelEvent: SingleLiveData<Unit> get() = _alertCancelEvent
 
-    private val termsOfUseUrl =
-        "https://silent-apparatus-578.notion.site/f1f5cd1609d4469dba3ab7d0f95c183c?pvs=4"
-    private val privacyUrl =
-        "https://silent-apparatus-578.notion.site/f1f5cd1609d4469dba3ab7d0f95c183c?pvs=4"
-    private val withdrawalUrl = "https://forms.gle/z5MUzVTUoyunfqEu8"
+        private val termsOfUseUrl =
+            "https://silent-apparatus-578.notion.site/f1f5cd1609d4469dba3ab7d0f95c183c?pvs=4"
+        private val privacyUrl =
+            "https://silent-apparatus-578.notion.site/f1f5cd1609d4469dba3ab7d0f95c183c?pvs=4"
+        private val withdrawalUrl = "https://forms.gle/z5MUzVTUoyunfqEu8"
 
-    val isNotificationActivate = MutableLiveData(true)
-    val isNotificationImportanceHigh = MutableLiveData(true)
+        val isNotificationActivate = MutableLiveData(true)
+        val isNotificationImportanceHigh = MutableLiveData(true)
 
-    private val _areNotificationsEnabled = MutableLiveData<Boolean>()
-    val areNotificationsEnabled: LiveData<Boolean> get() = _areNotificationsEnabled
+        private val _areNotificationsEnabled = MutableLiveData<Boolean>()
+        val areNotificationsEnabled: LiveData<Boolean> get() = _areNotificationsEnabled
 
-    init {
-        viewModelScope.launch {
-            initNotificationSwitches()
+        init {
+            viewModelScope.launch {
+                initNotificationSwitches()
+            }
+        }
+
+        private suspend fun initNotificationSwitches() {
+            isNotificationActivate.value = getNotificationActivateUseCase()
+            isNotificationImportanceHigh.value =
+                getNotificationImportanceUseCase() == NotificationManager.IMPORTANCE_HIGH
+        }
+
+        fun onClickTermsOfUse() {
+            _openUrlInBrowserEvent.setValue(termsOfUseUrl)
+        }
+
+        fun onClickPrivacy() {
+            _openUrlInBrowserEvent.setValue(privacyUrl)
+        }
+
+        fun onClickLogout() {
+            _showAlertEvent.setValue(Unit)
+        }
+
+        fun onClickWithdrawal() {
+            _openUrlInBrowserEvent.setValue(withdrawalUrl)
+        }
+
+        override fun onClickConfirm() {
+            viewModelScope.launch {
+                logoutUseCase()
+                _logoutEvent.setValue(Unit)
+            }
+        }
+
+        override fun onClickCancel() {
+            _alertCancelEvent.setValue(Unit)
+        }
+
+        fun onNotificationActivateSwitchChanged(isChecked: Boolean) {
+            isNotificationActivate.value = isChecked
+            viewModelScope.launch {
+                setNotificationActivateUseCase(isChecked)
+            }
+        }
+
+        fun onNotificationImportanceSwitchChanged(isChecked: Boolean) {
+            isNotificationImportanceHigh.value = isChecked
+            viewModelScope.launch {
+                val importance =
+                    if (isChecked) {
+                        NotificationManager.IMPORTANCE_HIGH
+                    } else {
+                        NotificationManager.IMPORTANCE_DEFAULT
+                    }
+                setNotificationImportanceUseCase(importance)
+            }
+        }
+
+        fun updateNotificationStatus(enabled: Boolean) {
+            _areNotificationsEnabled.value = enabled
         }
     }
-
-    private suspend fun initNotificationSwitches() {
-        isNotificationActivate.value = getNotificationActivateUseCase()
-        isNotificationImportanceHigh.value =
-            getNotificationImportanceUseCase() == NotificationManager.IMPORTANCE_HIGH
-    }
-
-    fun onClickTermsOfUse() {
-        _openUrlInBrowserEvent.setValue(termsOfUseUrl)
-    }
-
-    fun onClickPrivacy() {
-        _openUrlInBrowserEvent.setValue(privacyUrl)
-    }
-
-    fun onClickLogout() {
-        _showAlertEvent.setValue(Unit)
-    }
-
-    fun onClickWithdrawal() {
-        _openUrlInBrowserEvent.setValue(withdrawalUrl)
-    }
-
-    override fun onClickConfirm() {
-        viewModelScope.launch {
-            logoutUseCase()
-            _logoutEvent.setValue(Unit)
-        }
-    }
-
-    override fun onClickCancel() {
-        _alertCancelEvent.setValue(Unit)
-    }
-
-    fun onNotificationActivateSwitchChanged(isChecked: Boolean) {
-        isNotificationActivate.value = isChecked
-        viewModelScope.launch {
-            setNotificationActivateUseCase(isChecked)
-        }
-    }
-
-    fun onNotificationImportanceSwitchChanged(isChecked: Boolean) {
-        isNotificationImportanceHigh.value = isChecked
-        viewModelScope.launch {
-            val importance =
-                if (isChecked) {
-                    NotificationManager.IMPORTANCE_HIGH
-                } else {
-                    NotificationManager.IMPORTANCE_DEFAULT
-                }
-            setNotificationImportanceUseCase(importance)
-        }
-    }
-
-    fun updateNotificationStatus(enabled: Boolean) {
-        _areNotificationsEnabled.value = enabled
-    }
-}

--- a/android/app/src/main/res/layout/fragment_my_page.xml
+++ b/android/app/src/main/res/layout/fragment_my_page.xml
@@ -105,10 +105,23 @@
             layout="@layout/item_notification_switch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:isVisible="@{vm.areNotificationsEnabled}"
+            app:isVisibleOrInvisible="@{vm.areNotificationsEnabled}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_divider"
             app:vm="@{vm}" />
+
+        <TextView
+            style="@style/Theme.AppCompat.TextView.Bold.Black1000.Size15"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/my_page_notification_block_description"
+            android:gravity="center"
+            app:isVisible="@{!vm.areNotificationsEnabled}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/switch_notification"
+            app:layout_constraintTop_toBottomOf="@id/view_divider" />
+
 
         <ImageView
             android:id="@+id/iv_nickname_modification"

--- a/android/app/src/main/res/layout/fragment_my_page.xml
+++ b/android/app/src/main/res/layout/fragment_my_page.xml
@@ -101,28 +101,13 @@
             app:layout_constraintTop_toBottomOf="@id/tv_nickname_title" />
 
         <include
-            android:id="@+id/switch_notification_activate"
-            layout="@layout/item_switch"
+            android:id="@+id/switch_notification"
+            layout="@layout/item_notification_switch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:checked="@={vm.isNotificationActivate}"
-            app:label="@{@string/my_page_notification_available_text}"
+            app:isVisible="@{vm.areNotificationsEnabled}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_divider"
-            app:onCheckedChanged="@{(button, isChecked) -> vm.onNotificationActivateSwitchChanged(isChecked)}"
-            app:vm="@{vm}" />
-
-        <include
-            android:id="@+id/switch_notification_popup"
-            layout="@layout/item_switch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:checked="@={vm.isNotificationImportanceHigh}"
-            app:isVisible="@{vm.isNotificationActivate}"
-            app:label="@{@string/my_page_notification_setting_text}"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/switch_notification_activate"
-            app:onCheckedChanged="@{(button, isChecked) -> vm.onNotificationImportanceSwitchChanged(isChecked)}"
             app:vm="@{vm}" />
 
         <ImageView
@@ -135,25 +120,6 @@
             app:layout_constraintBottom_toBottomOf="@id/tv_nickname"
             app:layout_constraintStart_toEndOf="@id/tv_nickname_title"
             app:layout_constraintTop_toTopOf="@id/tv_nickname" />
-
-        <!--        <ImageView-->
-        <!--            android:id="@+id/iv_my_offerings"-->
-        <!--            android:layout_width="wrap_content"-->
-        <!--            android:layout_height="wrap_content"-->
-        <!--            android:layout_marginStart="42dp"-->
-        <!--            android:layout_marginTop="55dp"-->
-        <!--            android:src="@drawable/ic_my_page_my_offerings"-->
-        <!--            app:layout_constraintStart_toStartOf="parent"-->
-        <!--            app:layout_constraintTop_toBottomOf="@id/iv_profile" />-->
-
-        <!--        <TextView-->
-        <!--            android:id="@+id/tv_my_offerings"-->
-        <!--            style="@style/Theme.AppCompat.TextView.Bold.Black1000.Size14"-->
-        <!--            android:layout_marginStart="12dp"-->
-        <!--            android:text="@string/my_page_offerings_text"-->
-        <!--            app:layout_constraintBottom_toBottomOf="@id/iv_my_offerings"-->
-        <!--            app:layout_constraintStart_toEndOf="@id/iv_my_offerings"-->
-        <!--            app:layout_constraintTop_toTopOf="@id/iv_my_offerings" />-->
 
         <ImageView
             android:id="@+id/iv_terms_of_use"
@@ -174,7 +140,7 @@
             app:debouncedOnClick="@{() -> vm.onClickTermsOfUse()}"
             app:layout_constraintBottom_toBottomOf="@id/iv_terms_of_use"
             app:layout_constraintStart_toEndOf="@id/iv_terms_of_use"
-            app:layout_constraintTop_toBottomOf="@id/switch_notification_popup" />
+            app:layout_constraintTop_toBottomOf="@id/switch_notification" />
 
         <ImageView
             android:id="@+id/iv_privacy"

--- a/android/app/src/main/res/layout/fragment_offering_write_essential.xml
+++ b/android/app/src/main/res/layout/fragment_offering_write_essential.xml
@@ -95,7 +95,7 @@
 
                 <EditText
                     android:id="@+id/et_total_personnel"
-                    android:layout_width="80dp"
+                    android:layout_width="60dp"
                     android:layout_height="34dp"
                     android:layout_marginStart="@dimen/size_7"
                     android:layout_marginTop="-1dp"
@@ -160,7 +160,7 @@
 
                 <EditText
                     android:id="@+id/et_my_count"
-                    android:layout_width="80dp"
+                    android:layout_width="60dp"
                     android:layout_height="34dp"
                     android:layout_marginStart="@dimen/size_7"
                     android:layout_marginTop="-1dp"

--- a/android/app/src/main/res/layout/item_notification_switch.xml
+++ b/android/app/src/main/res/layout/item_notification_switch.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.zzang.chongdae.presentation.view.mypage.MyPageViewModel" />
+
+        <variable
+            name="label"
+            type="String" />
+
+        <variable
+            name="checked"
+            type="Boolean" />
+
+        <variable
+            name="onCheckedChanged"
+            type="android.widget.CompoundButton.OnCheckedChangeListener" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include
+            android:id="@+id/switch_notification_activate"
+            layout="@layout/item_switch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:checked="@={vm.isNotificationActivate}"
+            app:label="@{@string/my_page_notification_available_text}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:onCheckedChanged="@{(button, isChecked) -> vm.onNotificationActivateSwitchChanged(isChecked)}"
+            app:vm="@{vm}" />
+
+        <include
+            android:id="@+id/switch_notification_popup"
+            layout="@layout/item_switch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:checked="@={vm.isNotificationImportanceHigh}"
+            app:isVisible="@{vm.isNotificationActivate}"
+            app:label="@{@string/my_page_notification_setting_text}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/switch_notification_activate"
+            app:onCheckedChanged="@{(button, isChecked) -> vm.onNotificationImportanceSwitchChanged(isChecked)}"
+            app:vm="@{vm}" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="my_page_title_text">마이페이지</string>
     <string name="my_page_offerings_text">내가 올린 공구</string>
     <string name="my_page_logout_dialog_description">로그아웃 하시겠습니까?</string>
+    <string name="my_page_notification_block_description">현재 스마트폰 설정에서 총대마켓의 푸시알림이\n차단되어 있습니다. 알림을 허용해주세요.</string>
 
     <!--    offering_detail-->
     <string name="offering_detail_product_url_title">물품 링크:&#160;</string>


### PR DESCRIPTION
## 📌 관련 이슈
close #739 

## ✨ 작업 내용
- 스마트폰 설정에서 총대마켓의 푸시알림을 해제했을 시 마이페이지에서 푸시알림 스위치가 사라지고 안내문구를 띄우도록 했습니다.
- 좁은 폰에선 내가 가질 개수 선택 버튼이 잘려서 개수 입력칸의 width를 80에서 60으로 줄였습니다.

## 📚 기타

https://github.com/user-attachments/assets/23475e38-c495-40ba-adb2-b52454bbd206

