### PR TITLE
feat: 채팅이 없으면 최신 참여 날짜 순으로 정렬하도록 수정

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
@@ -78,17 +78,18 @@ public class CommentService {
     private CommentRoomAllResponseItem getCommentRoom(Long offeringId, MemberEntity member) {
         OfferingMemberEntity offeringMember = offeringMemberRepository.findByOfferingIdAndMember(offeringId, member)
                 .orElseThrow(() -> new MarketException(OfferingMemberErrorCode.NOT_FOUND));
-        CommentLatestResponse latestComment = getLatestComment(offeringId);
+        CommentLatestResponse latestComment = getLatestComment(offeringMember);
         if (offeringRepository.existsById(offeringId)) {
             return new CommentRoomAllResponseItem(offeringMember.getOffering(), offeringMember, latestComment);
         }
         return new CommentRoomAllResponseItem(offeringId, offeringMember, latestComment);
     }
 
-    private CommentLatestResponse getLatestComment(Long offeringId) {
-        Optional<CommentEntity> comment = commentRepository.findTopByOfferingIdOrderByCreatedAtDesc(offeringId);
+    private CommentLatestResponse getLatestComment(OfferingMemberEntity offeringMember) {
+        Optional<CommentEntity> comment = commentRepository.findTopByOfferingIdOrderByCreatedAtDesc(
+                offeringMember.getId());
         return comment.map(CommentLatestResponse::new)
-                .orElseGet(() -> new CommentLatestResponse(null, null));
+                .orElseGet(() -> new CommentLatestResponse(null, offeringMember.getCreatedAt()));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/zzang/chongdae/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/comment/service/CommentServiceTest.java
@@ -56,7 +56,7 @@ public class CommentServiceTest extends ServiceTest {
             assertEquals(response.offerings().size(), 4);
         }
 
-        @DisplayName("최근 댓글이 작성된 순으로 정렬해 댓글방 목록을 조회할 수 있다")
+        @DisplayName("최근 댓글이 작성된 순으로 (댓글이 없으면 최근 참여 날짜로) 정렬해 댓글방 목록을 조회할 수 있다")
         @Test
         void should_getAllCommentRoomWithOrder_when_givenLoginMember() {
             // when
@@ -65,7 +65,7 @@ public class CommentServiceTest extends ServiceTest {
             // then
             assertThat(response.offerings())
                     .extracting(CommentRoomAllResponseItem::offeringId)
-                    .containsExactly(2L, 1L, 3L, 4L);
+                    .containsExactly(2L, 1L, 4L, 3L);
         }
 
         @DisplayName("댓글방 목록 조회 시 삭제된 공모에 대한 댓글방은 제목에 삭제되었다고 명시되어 있다")


### PR DESCRIPTION
## 📌 관련 이슈
- #758

## ✨ 작업 내용

채팅이 없으면 최신 참여 날짜 순으로 정렬하도록 수정했습니다.

현재 채팅방 조회 구조에서 offeringmember를 무조건 조회하기 때문에 해당 최신 생성 시간을 이용하여 정렬하도록 변경했습니다.

## 📚 기타
