### PR TITLE
feat: 거래가 완료되면 나갈 수 있도록 변경

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
@@ -34,7 +34,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "id", callSuper = false)
-@SQLDelete(sql = "UPDATE offering SET is_deleted = true, version = version + 1 WHERE id = ? AND version = ?")
+@SQLDelete(sql = "UPDATE offering SET is_deleted = true, version = version + 1, room_status = 'DELETED' WHERE id = ? AND version = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "offering")
 @Entity

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -81,13 +81,7 @@ public class OfferingMemberService {
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
         OfferingMemberEntity offeringMember = offeringMemberRepository.findByOfferingIdAndMember(offeringId, member)
                 .orElseThrow(() -> new MarketException(OfferingMemberErrorCode.PARTICIPANT_NOT_FOUND));
-
-        // TODO: 삭제된 공모 상태 변경(DELETED) 하기
-        if (offeringRepository.existsById(offeringId)) {
-            validateCancel(offeringMember);
-
-        }
-
+        validateCancel(offeringMember);
         offeringMemberRepository.delete(offeringMember);
         offering.leave(offeringMember.getParticipationCount());
 

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -95,7 +95,9 @@ public class OfferingMemberService {
     }
 
     private void validateIsProposer(OfferingMemberEntity offeringMember) {
-        if (offeringMember.isProposer()) {
+        OfferingEntity offering = offeringMember.getOffering();
+        CommentRoomStatus roomStatus = offering.getRoomStatus();
+        if (offeringMember.isProposer() && (roomStatus.isInProgress() || roomStatus.isGrouping())) {
             throw new MarketException(OfferingMemberErrorCode.CANNOT_CANCEL_PROPOSER);
         }
     }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -77,11 +77,16 @@ public class OfferingMemberService {
     @WriterDatabase
     @Transactional
     public void cancelParticipate(Long offeringId, MemberEntity member) {
-        OfferingEntity offering = offeringRepository.findById(offeringId)
+        OfferingEntity offering = offeringRepository.findByIdWithDeleted(offeringId)
                 .orElseThrow(() -> new MarketException(OfferingErrorCode.NOT_FOUND));
-        OfferingMemberEntity offeringMember = offeringMemberRepository.findByOfferingAndMember(offering, member)
+        OfferingMemberEntity offeringMember = offeringMemberRepository.findByOfferingIdAndMember(offeringId, member)
                 .orElseThrow(() -> new MarketException(OfferingMemberErrorCode.PARTICIPANT_NOT_FOUND));
-        validateCancel(offeringMember);
+
+        // TODO: 삭제된 공모 상태 변경(DELETED) 하기
+        if (offeringRepository.existsById(offeringId)) {
+            validateCancel(offeringMember);
+
+        }
 
         offeringMemberRepository.delete(offeringMember);
         offering.leave(offeringMember.getParticipationCount());

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -103,7 +103,7 @@ public class OfferingMemberService {
     private void validateInProgress(OfferingMemberEntity offeringMember) {
         OfferingEntity offering = offeringMember.getOffering();
         CommentRoomStatus roomStatus = offering.getRoomStatus();
-        if (roomStatus.isGrouped()) {
+        if (roomStatus.isInProgress()) {
             throw new MarketException(OfferingMemberErrorCode.CANNOT_CANCEL_IN_PROGRESS);
         }
     }

--- a/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offering/service/OfferingServiceTest.java
@@ -9,6 +9,7 @@ import com.zzang.chongdae.global.service.ServiceTest;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offering.domain.CommentRoomStatus;
 import com.zzang.chongdae.offering.domain.OfferingStatus;
+import com.zzang.chongdae.offering.repository.OfferingRepository;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import com.zzang.chongdae.offering.service.dto.OfferingAllResponse;
 import com.zzang.chongdae.offering.service.dto.OfferingAllResponseItem;
@@ -27,6 +28,9 @@ public class OfferingServiceTest extends ServiceTest {
 
     @Autowired
     OfferingService offeringService;
+
+    @Autowired
+    OfferingRepository offeringRepository;
 
     @DisplayName("공모 상세 조회")
     @Nested
@@ -592,6 +596,22 @@ public class OfferingServiceTest extends ServiceTest {
 
             // then
             assertThat(offeringFixture.countOffering()).isEqualTo(0);
+        }
+
+        @DisplayName("삭제된 공모의 채팅방 상태는 DELETED 이다.")
+        @Test
+        void should_commentStatusIsDeleted_when_deleteOffering() {
+            // given
+            OfferingEntity offering = offeringFixture.createOffering(proposer, CommentRoomStatus.DONE);
+            CommentRoomStatus expected = CommentRoomStatus.DELETED;
+
+            // when
+            offeringService.deleteOffering(offering.getId(), proposer);
+            OfferingEntity deletedOffering = offeringRepository.findByIdWithDeleted(offering.getId()).get();
+            CommentRoomStatus actual = deletedOffering.getRoomStatus();
+
+            // then
+            assertThat(actual).isEqualTo(expected);
         }
     }
 }

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class OfferingMemberServiceConcurrencyTest extends ServiceTest {
+class OfferingMemberServiceTest extends ServiceTest {
 
     @Autowired
     OfferingMemberService offeringMemberService;
@@ -79,7 +79,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
 
         @DisplayName("진행중인 공모 중에 참여자는 나갈 수 없다.")
         @Test
-        void should_participantFailCancelParticipate_when_offeringIsNotGrouping() throws InterruptedException {
+        void should_participantFailCancelParticipate_when_offeringIsNotGrouping() {
             // given
             MemberEntity proposer = memberFixture.createMember("poke");
             OfferingEntity offering = offeringFixture.createOffering(proposer);
@@ -99,7 +99,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
 
         @DisplayName("거래가 완료된 공모일 경우 참여자는 나갈 수 있다.")
         @Test
-        void should_participantCancelParticipate_when_offeringIsDone() throws InterruptedException {
+        void should_participantCancelParticipate_when_offeringIsDone() {
             // given
             MemberEntity proposer = memberFixture.createMember("poke");
             OfferingEntity offering = offeringFixture.createOffering(proposer);
@@ -121,7 +121,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
 
         @DisplayName("삭제된 공모일 경우 총대는 나갈 수 있다.")
         @Test
-        void should_participantCancelParticipate_when_offeringIsDeleted() throws InterruptedException {
+        void should_participantCancelParticipate_when_offeringIsDeleted() {
             // given
             MemberEntity proposer = memberFixture.createMember("poke");
             OfferingEntity offering = offeringFixture.createOffering(proposer);
@@ -141,7 +141,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
 
         @DisplayName("모집중에 총대는 나갈 수 없다.")
         @Test
-        void should_proposerFailCancelParticipate_when_offeringIsNotGrouping() throws InterruptedException {
+        void should_proposerFailCancelParticipate_when_offeringIsNotGrouping() {
             // given
             MemberEntity proposer = memberFixture.createMember("poke");
             OfferingEntity offering = offeringFixture.createOffering(proposer);
@@ -160,7 +160,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
 
         @DisplayName("거래가 완료된 공모일 경우 총대는 나갈 수 있다.")
         @Test
-        void should_proposerCancelParticipate_when_offeringIsDone() throws InterruptedException {
+        void should_proposerCancelParticipate_when_offeringIsDone() {
             // given
             MemberEntity proposer = memberFixture.createMember("poke");
             OfferingEntity offering = offeringFixture.createOffering(proposer);
@@ -182,7 +182,7 @@ class OfferingMemberServiceConcurrencyTest extends ServiceTest {
 
         @DisplayName("삭제된 공모일 경우 총대는 나갈 수 있다.")
         @Test
-        void should_proposerCancelParticipate_when_offeringIsDeleted() throws InterruptedException {
+        void should_proposerCancelParticipate_when_offeringIsDeleted() {
             // given
             MemberEntity proposer = memberFixture.createMember("poke");
             OfferingEntity offering = offeringFixture.createOffering(proposer);

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
@@ -73,7 +73,7 @@ class OfferingMemberServiceTest extends ServiceTest {
         assertThat(response.participants()).hasSize(1);
     }
 
-    @DisplayName("참여자 나가기 테스트")
+    @DisplayName("채팅방 나가기 테스트")
     @Nested
     class CancelParticipateWithParticipant {
 
@@ -119,7 +119,7 @@ class OfferingMemberServiceTest extends ServiceTest {
                     .doesNotThrowAnyException();
         }
 
-        @DisplayName("삭제된 공모일 경우 총대는 나갈 수 있다.")
+        @DisplayName("삭제된 공모일 경우 참여자는 나갈 수 있다.")
         @Test
         void should_participantCancelParticipate_when_offeringIsDeleted() {
             // given


### PR DESCRIPTION
## 📌 관련 이슈
- #759 
## ✨ 작업 내용

총대와 참여자가 거래가 완료되면 나갈 수 있도록 변경했습니다.

총대 나가기 정책

- 삭제 또는 거래가 완료되어야 나갈 수 있습니다.

참여자 나가기 정책

- 모집중, 삭제, 거래가 완료되어야 나갈 수 있습니다. 

## 📚 기타

공모 삭제 시 `CommentRoomStatus`를 변경하지 않아서 DELETED로 변경하도록 수정했어요!
