### PR TITLE
feat: 정산 여부 조회, 변경 기능 구현

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/controller/OfferingMemberController.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/controller/OfferingMemberController.java
@@ -2,6 +2,8 @@ package com.zzang.chongdae.offeringmember.controller;
 
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offeringmember.service.OfferingMemberService;
+import com.zzang.chongdae.offeringmember.service.dto.ChangeSettleRequest;
+import com.zzang.chongdae.offeringmember.service.dto.ChangeSettleResponse;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponse;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
 import jakarta.validation.Valid;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -42,6 +45,14 @@ public class OfferingMemberController {
             @RequestParam(value = "offering-id") Long offeringId,
             MemberEntity member) {
         ParticipantResponse response = offeringMemberService.getAllParticipant(offeringId, member);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/participants")
+    public ResponseEntity<ChangeSettleResponse> changeSettleStatus(
+            @RequestBody ChangeSettleRequest request,
+            MemberEntity member) {
+        ChangeSettleResponse response = offeringMemberService.changeSettleStatus(request, member);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/repository/entity/OfferingMemberEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/repository/entity/OfferingMemberEntity.java
@@ -66,4 +66,8 @@ public class OfferingMemberEntity extends BaseTimeEntity {
     public boolean isParticipant() {
         return this.role.isParticipant();
     }
+
+    public void changeSettle() {
+        this.isSettled = !(this.isSettled);
+    }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/repository/entity/OfferingMemberEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/repository/entity/OfferingMemberEntity.java
@@ -20,6 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -50,8 +51,12 @@ public class OfferingMemberEntity extends BaseTimeEntity {
     @Positive
     private Integer participationCount = DEFAULT_PARTICIPATION_COUNT;
 
+    @NotNull
+    @ColumnDefault("false")
+    private Boolean isSettled;
+
     public OfferingMemberEntity(MemberEntity member, OfferingEntity offering, OfferingMemberRole role, Integer count) {
-        this(null, member, offering, role, count);
+        this(null, member, offering, role, count, false);
     }
 
     public boolean isProposer() {

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/OfferingMemberService.java
@@ -135,10 +135,10 @@ public class OfferingMemberService {
     public ChangeSettleResponse changeSettleStatus(ChangeSettleRequest request, MemberEntity member) {
         Long offeringId = request.offeringId();
         Long memberId = request.memberId();
-        MemberEntity participantMember = memberRepository.findById(memberId)
+        MemberEntity requestedMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MarketException(MemberErrorCode.NOT_FOUND));
         validateIsProposerOfOffering(offeringId, member);
-        OfferingMemberEntity participant = changeParticipantSettleStatus(offeringId, participantMember);
+        OfferingMemberEntity participant = changeParticipantSettleStatus(offeringId, requestedMember);
         return new ChangeSettleResponse(participant);
     }
 

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ChangeSettleRequest.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ChangeSettleRequest.java
@@ -1,0 +1,4 @@
+package com.zzang.chongdae.offeringmember.service.dto;
+
+public record ChangeSettleRequest(Long offeringId, Long memberId) {
+}

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ChangeSettleResponse.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ChangeSettleResponse.java
@@ -1,0 +1,11 @@
+package com.zzang.chongdae.offeringmember.service.dto;
+
+import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
+
+public record ChangeSettleResponse(Long offeringId, Long memberId, Boolean isSettled) {
+    public ChangeSettleResponse(OfferingMemberEntity offeringMember) {
+        this(offeringMember.getOffering().getId(),
+                offeringMember.getMember().getId(),
+                offeringMember.getIsSettled());
+    }
+}

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponseItem.java
@@ -4,11 +4,13 @@ import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
 
 public record ParticipantResponseItem(String nickname,
                                       Integer count,
-                                      Integer price) {
+                                      Integer price,
+                                      Boolean isSettled) {
 
     public ParticipantResponseItem(OfferingMemberEntity offeringMember, int pricePerOne) {
         this(offeringMember.getMember().getNickname(),
                 offeringMember.getParticipationCount(),
-                offeringMember.getParticipationCount() * pricePerOne);
+                offeringMember.getParticipationCount() * pricePerOne,
+                offeringMember.getIsSettled());
     }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponseItem.java
+++ b/backend/src/main/java/com/zzang/chongdae/offeringmember/service/dto/ParticipantResponseItem.java
@@ -2,13 +2,15 @@ package com.zzang.chongdae.offeringmember.service.dto;
 
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
 
-public record ParticipantResponseItem(String nickname,
+public record ParticipantResponseItem(Long memberId,
+                                      String nickname,
                                       Integer count,
                                       Integer price,
                                       Boolean isSettled) {
 
     public ParticipantResponseItem(OfferingMemberEntity offeringMember, int pricePerOne) {
-        this(offeringMember.getMember().getNickname(),
+        this(offeringMember.getId(),
+                offeringMember.getMember().getNickname(),
                 offeringMember.getParticipationCount(),
                 offeringMember.getParticipationCount() * pricePerOne,
                 offeringMember.getIsSettled());

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/integration/OfferingMemberIntegrationTest.java
@@ -371,6 +371,7 @@ public class OfferingMemberIntegrationTest extends IntegrationTest {
                 fieldWithPath("participants[].nickname").description("공모 참여자 닉네임"),
                 fieldWithPath("participants[].count").description("공모 참여자 참여 개수"),
                 fieldWithPath("participants[].price").description("공모 참여자 지불할 금액"),
+                fieldWithPath("participants[].isSettled").description("참여자 정산 완료 여부"),
                 fieldWithPath("count.currentCount").description("공모 참여자 현재원(작성자 + 참여자)"),
                 fieldWithPath("count.totalCount").description("공모 참여자 총원"),
                 fieldWithPath("price").description("공모 참여자 예상 정산 가격 - 현재는 불필요하지만 이전 버전 앱을 위해 남겨두었습니다.")


### PR DESCRIPTION
## 📌 관련 이슈
- #764 

## ✨ 작업 내용

- 채팅방에서 참여자들의 정산 여부를 조회하고 변경할 수 있도록 API를 개발했습니다.
- Real 시스템 내 정산 기능은 매우 복잡해서, 간단하게 체크만 할 수 있으면 어떨지 고민하다 제안했습니다!

## 📚 기타

총대만 참여자들의 정산 여부를 변경할 수 있도록 구현했습니다
클라이언트 측에선 `참여자` 들이 다른 `참여자`들을 터치하지 못하도록 (혹은 응답이 없도록) 구현하면 될 것 같아요! 
