### PR TITLE
fix: 참여 공모 조회 시 최근 댓글 반환 안 되는 이슈 해결

### DIFF
--- a/.github/workflows/backend-dev-ci.yml
+++ b/.github/workflows/backend-dev-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "chongdae" ]
     paths:
       - "backend/**"
+      - ".github/workflows/backend-dev-ci.yml"
 
 jobs:
 
@@ -43,5 +44,5 @@ jobs:
         working-directory: ./backend
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew clean build
+        run: ./gradlew clean build --stacktrace --info
         working-directory: ./backend

--- a/.github/workflows/backend-dev-ci.yml
+++ b/.github/workflows/backend-dev-ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "chongdae" ]
     paths:
       - "backend/**"
-      - ".github/workflows/backend-dev-ci.yml"
 
 jobs:
 
@@ -44,5 +43,5 @@ jobs:
         working-directory: ./backend
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew clean build --stacktrace --info
+        run: ./gradlew clean build
         working-directory: ./backend

--- a/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
+++ b/backend/src/main/java/com/zzang/chongdae/comment/service/CommentService.java
@@ -87,7 +87,7 @@ public class CommentService {
 
     private CommentLatestResponse getLatestComment(OfferingMemberEntity offeringMember) {
         Optional<CommentEntity> comment = commentRepository.findTopByOfferingIdOrderByCreatedAtDesc(
-                offeringMember.getId());
+                offeringMember.getOffering().getId());
         return comment.map(CommentLatestResponse::new)
                 .orElseGet(() -> new CommentLatestResponse(null, offeringMember.getCreatedAt()));
     }

--- a/backend/src/test/java/com/zzang/chongdae/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/comment/service/CommentServiceTest.java
@@ -14,6 +14,7 @@ import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offering.domain.CommentRoomStatus;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -90,7 +91,9 @@ public class CommentServiceTest extends ServiceTest {
             assertEquals(response.offerings().size(), 2);
             assertEquals(topOffering.offeringId(), firstOffering.getId());
             assertEquals(latestComment.content(), newComment.getContent());
-            assertEquals(latestComment.createdAt(), newComment.getCreatedAt());
+            assertEquals(latestComment.createdAt().truncatedTo(ChronoUnit.MICROS),
+                    newComment.getCreatedAt().truncatedTo(ChronoUnit.MICROS));
+
         }
 
         @DisplayName("댓글방 목록 조회 시 가장 최근 댓글 정보가 없는 경우 내용은 null, 생성일시는 참여 날짜로 조회한다")
@@ -108,7 +111,8 @@ public class CommentServiceTest extends ServiceTest {
             CommentLatestResponse latestComment = offeringWithoutComment.latestComment();
             assertEquals(response.offerings().size(), 1);
             assertNull(latestComment.content());
-            assertEquals(latestComment.createdAt(), offeringMember.getCreatedAt());
+            assertEquals(latestComment.createdAt().truncatedTo(ChronoUnit.MICROS),
+                    offeringMember.getCreatedAt().truncatedTo(ChronoUnit.MICROS));
         }
 
         @DisplayName("댓글방 목록 조회 시 삭제된 공모에 대한 댓글방은 제목에 삭제되었다고 명시되어 있다")

--- a/backend/src/test/java/com/zzang/chongdae/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/comment/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.zzang.chongdae.comment.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.zzang.chongdae.comment.repository.entity.CommentEntity;
 import com.zzang.chongdae.comment.service.dto.CommentLatestResponse;
@@ -91,9 +92,10 @@ public class CommentServiceTest extends ServiceTest {
             assertEquals(response.offerings().size(), 2);
             assertEquals(topOffering.offeringId(), firstOffering.getId());
             assertEquals(latestComment.content(), newComment.getContent());
-            assertEquals(latestComment.createdAt().truncatedTo(ChronoUnit.MICROS),
-                    newComment.getCreatedAt().truncatedTo(ChronoUnit.MICROS));
-
+            assertTrue(Math.abs(ChronoUnit.MILLIS.between(
+                    latestComment.createdAt(),
+                    newComment.getCreatedAt()
+            )) <= 100);
         }
 
         @DisplayName("댓글방 목록 조회 시 가장 최근 댓글 정보가 없는 경우 내용은 null, 생성일시는 참여 날짜로 조회한다")
@@ -111,8 +113,10 @@ public class CommentServiceTest extends ServiceTest {
             CommentLatestResponse latestComment = offeringWithoutComment.latestComment();
             assertEquals(response.offerings().size(), 1);
             assertNull(latestComment.content());
-            assertEquals(latestComment.createdAt().truncatedTo(ChronoUnit.MICROS),
-                    offeringMember.getCreatedAt().truncatedTo(ChronoUnit.MICROS));
+            assertTrue(Math.abs(ChronoUnit.MILLIS.between(
+                    latestComment.createdAt(),
+                    offeringMember.getCreatedAt()
+            )) <= 100);
         }
 
         @DisplayName("댓글방 목록 조회 시 삭제된 공모에 대한 댓글방은 제목에 삭제되었다고 명시되어 있다")

--- a/backend/src/test/java/com/zzang/chongdae/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/comment/service/CommentServiceTest.java
@@ -2,7 +2,10 @@ package com.zzang.chongdae.comment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.zzang.chongdae.comment.repository.entity.CommentEntity;
+import com.zzang.chongdae.comment.service.dto.CommentLatestResponse;
 import com.zzang.chongdae.comment.service.dto.CommentRoomAllResponse;
 import com.zzang.chongdae.comment.service.dto.CommentRoomAllResponseItem;
 import com.zzang.chongdae.comment.service.dto.CommentRoomInfoResponse;
@@ -10,6 +13,7 @@ import com.zzang.chongdae.global.service.ServiceTest;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
 import com.zzang.chongdae.offering.domain.CommentRoomStatus;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
+import com.zzang.chongdae.offeringmember.repository.entity.OfferingMemberEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -66,6 +70,45 @@ public class CommentServiceTest extends ServiceTest {
             assertThat(response.offerings())
                     .extracting(CommentRoomAllResponseItem::offeringId)
                     .containsExactly(2L, 1L, 4L, 3L);
+        }
+
+        @DisplayName("댓글방 목록 조회 시 가장 최근 댓글 정보를 함께 조회한다")
+        @Test
+        void should_getAllCommentRoomWithLatestComment() {
+            // given
+            MemberEntity participant = memberFixture.createMember("ever");
+            offeringMemberFixture.createParticipant(participant, firstOffering);
+            offeringMemberFixture.createParticipant(participant, secondOffering);
+            CommentEntity newComment = commentFixture.createComment(participant, firstOffering);
+
+            // when
+            CommentRoomAllResponse response = commentService.getAllCommentRoom(participant);
+
+            // then
+            CommentRoomAllResponseItem topOffering = response.offerings().get(0);
+            CommentLatestResponse latestComment = topOffering.latestComment();
+            assertEquals(response.offerings().size(), 2);
+            assertEquals(topOffering.offeringId(), firstOffering.getId());
+            assertEquals(latestComment.content(), newComment.getContent());
+            assertEquals(latestComment.createdAt(), newComment.getCreatedAt());
+        }
+
+        @DisplayName("댓글방 목록 조회 시 가장 최근 댓글 정보가 없는 경우 내용은 null, 생성일시는 참여 날짜로 조회한다")
+        @Test
+        void should_getAllCommentRoomWithLatestComment_when_noComment() {
+            // given
+            MemberEntity participant = memberFixture.createMember("ever");
+            OfferingMemberEntity offeringMember = offeringMemberFixture.createParticipant(participant, thirdOffering);
+
+            // when
+            CommentRoomAllResponse response = commentService.getAllCommentRoom(participant);
+
+            // then
+            CommentRoomAllResponseItem offeringWithoutComment = response.offerings().get(0);
+            CommentLatestResponse latestComment = offeringWithoutComment.latestComment();
+            assertEquals(response.offerings().size(), 1);
+            assertNull(latestComment.content());
+            assertEquals(latestComment.createdAt(), offeringMember.getCreatedAt());
         }
 
         @DisplayName("댓글방 목록 조회 시 삭제된 공모에 대한 댓글방은 제목에 삭제되었다고 명시되어 있다")


### PR DESCRIPTION
## 📌 관련 이슈
close #773 
## ✨ 작업 내용
- 잘못된 파라미터(offeringMemberId)가 전달되고 있었던 문제 -> 옳은 파라미터(offeringId) 전달하도록 변경
- 관련 테스트 케이스 추가하여 커버리지 높이기
## 📚 기타
