### PR TITLE
fix: 모집중인 공모만 상태를 변경하도록 수정

### DIFF
--- a/backend/src/main/java/com/zzang/chongdae/offering/domain/OfferingStatus.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/domain/OfferingStatus.java
@@ -24,4 +24,8 @@ public enum OfferingStatus {
     public boolean isClosed() {
         return this == CONFIRMED || this == FULL;
     }
+
+    public boolean isGrouping() {
+        return this != CONFIRMED;
+    }
 }

--- a/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
+++ b/backend/src/main/java/com/zzang/chongdae/offering/repository/entity/OfferingEntity.java
@@ -141,8 +141,10 @@ public class OfferingEntity extends BaseTimeEntity {
 
     public void leave(int participationCount) {
         currentCount -= participationCount;
-        OfferingStatus offeringStatus = toOfferingJoinedCount().decideOfferingStatus();
-        updateOfferingStatus(offeringStatus);
+        if (this.offeringStatus.isGrouping()) {
+            OfferingStatus offeringStatus = toOfferingJoinedCount().decideOfferingStatus();
+            updateOfferingStatus(offeringStatus);
+        }
     }
 
     public CommentRoomStatus moveCommentRoomStatus() {

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
@@ -204,7 +204,7 @@ class OfferingMemberServiceTest extends ServiceTest {
 
         @DisplayName("거래가 완료된 공모에 참여자가 나갈 경우 공모의 상태는 변경되지 않는다.")
         @Test
-        void should_offeringStatusNotChange_when_offeringIsDone() {
+        void should_offeringStatusNotChange_when_offeringIsConfirmed() {
             // given
             MemberEntity proposer = memberFixture.createMember("poke");
 

--- a/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
+++ b/backend/src/test/java/com/zzang/chongdae/offeringmember/service/OfferingMemberServiceTest.java
@@ -9,8 +9,10 @@ import com.zzang.chongdae.global.exception.MarketException;
 import com.zzang.chongdae.global.helper.ConcurrencyExecutor;
 import com.zzang.chongdae.global.service.ServiceTest;
 import com.zzang.chongdae.member.repository.entity.MemberEntity;
+import com.zzang.chongdae.offering.domain.OfferingStatus;
 import com.zzang.chongdae.offering.repository.entity.OfferingEntity;
 import com.zzang.chongdae.offering.service.OfferingService;
+import com.zzang.chongdae.offering.service.dto.OfferingAllResponseItem;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipantResponse;
 import com.zzang.chongdae.offeringmember.service.dto.ParticipationRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -198,6 +200,39 @@ class OfferingMemberServiceTest extends ServiceTest {
             // then
             assertThatCode(() -> offeringMemberService.cancelParticipate(offering.getId(), proposer))
                     .doesNotThrowAnyException();
+        }
+
+        @DisplayName("거래가 완료된 공모에 참여자가 나갈 경우 공모의 상태는 변경되지 않는다.")
+        @Test
+        void should_offeringStatusNotChange_when_offeringIsDone() {
+            // given
+            MemberEntity proposer = memberFixture.createMember("poke");
+
+            // 생성된 공모의 총 개수는 5개 입니다.
+            OfferingEntity offering = offeringFixture.createOffering(proposer);
+            offeringMemberFixture.createProposer(proposer, offering);
+
+            ParticipationRequest request1 = new ParticipationRequest(offering.getId(), 3);
+            MemberEntity participant1 = memberFixture.createMember("pokemon");
+            ParticipationRequest request2 = new ParticipationRequest(offering.getId(), 1);
+            MemberEntity participant2 = memberFixture.createMember("pokemon2");
+
+            OfferingStatus expected = OfferingStatus.CONFIRMED;
+
+            // when
+            offeringMemberService.participate(request1, participant1);
+            offeringMemberService.participate(request2, participant2);
+
+            commentService.updateCommentRoomStatus(offering.getId(), proposer); // Buying
+            commentService.updateCommentRoomStatus(offering.getId(), proposer); // Trading
+            commentService.updateCommentRoomStatus(offering.getId(), proposer); // Done
+
+            offeringMemberService.cancelParticipate(offering.getId(), participant2);
+            OfferingAllResponseItem result = offeringService.getOffering(offering.getId());
+            OfferingStatus actual = result.status();
+
+            // then
+            assertThat(actual).isEqualTo(expected);
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #776 

## ✨ 작업 내용
- 거래가 완료된 공모에서 참여자가 공모를 나갈 때 공모의 상태가 변경되는 현상을 수정했습니다!

## 📚 기타
